### PR TITLE
Tighten guided research contracts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,18 @@ be hard to misuse and explicit about trust.
 
 - **Default research entrypoint**: `research` handles discovery, known-item
   recovery, citation repair, and regulatory routing in one trust-graded path.
-- **Grounded follow-up**: `follow_up_research` uses `searchSessionId` and can
-  abstain when evidence is weak or unsupported.
+- **Grounded follow-up**: `follow_up_research` answers against one saved
+  `searchSessionId`; if you omit it, the server only infers a session when the
+  choice is unique.
 - **Reference-first recovery**: `resolve_reference` handles DOI/arXiv/URL,
-  citation fragments, and regulatory-style references.
+  citation fragments, and regulatory-style references, and exact DOI/arXiv/
+  paper-URL inputs resolve as exact anchors rather than falling through to fuzzy repair.
 - **Source auditability**: `inspect_source` exposes one `sourceId` with
-  provenance, trust state, and direct-read next steps.
+  provenance, trust state, and direct-read next steps; omitted `searchSessionId`
+  is only accepted when one compatible saved session exists.
 - **Runtime truth**: `get_runtime_status` surfaces active profile/transport and
-  provider-state warnings without requiring low-level diagnostics.
+  provider-state warnings without requiring low-level diagnostics. `configuredSmartProvider`
+  is the configured smart bundle; `activeSmartProvider` is the latest effective execution path.
 - **Expert depth remains available**: raw/smart/provider-specific tools still
   exist for operator workflows under the expert profile.
 
@@ -133,11 +137,14 @@ follow_up_research(searchSessionId="...", question="What evaluation tradeoffs sh
 → inspect answerStatus
 → if answered: use answer + evidence
 → if abstained/insufficient_evidence: use nextActions and inspect_source
+→ if you omit searchSessionId and multiple saved sessions exist: provide it explicitly
 ```
 
 ### 3. Resolve references before broad search when possible
 
 ```text
+resolve_reference(reference="10.1038/nrn3241")
+→ exact DOI/arXiv/paper URL should resolve directly when supported
 resolve_reference(reference="Rockstrom et al planetary boundaries 2009 Nature 461 472")
 → inspect status and bestMatch/alternatives
 → if resolved: run research with the resolved anchor
@@ -148,6 +155,7 @@ resolve_reference(reference="Rockstrom et al planetary boundaries 2009 Nature 46
 ```text
 inspect_source(searchSessionId="...", sourceId="...")
 → inspect verificationStatus, topicalRelevance, canonicalUrl, directReadRecommendations
+→ if searchSessionId is omitted and inference is ambiguous, rerun with an explicit saved session id
 ```
 
 ### 5. Handle abstention and clarification explicitly

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -27,12 +27,14 @@ next steps without re-discovering project state.
   appear as verified findings or timeline events.
 - Runtime reporting is now **internally truthful**. `get_runtime_status` and
   expert diagnostics should agree on `effectiveProfile`, smart-provider state,
-  and active/disabled provider sets.
+  and active/disabled provider sets. `configuredSmartProvider` is the configured
+  smart bundle; `activeSmartProvider` is the latest effective execution path,
+  including deterministic fallback when smart execution degrades.
 - The current checked-in package version is `0.2.1` in both `pyproject.toml`
   and `server.json`.
 - The current coverage-gated validation baseline after the latest release-readiness pass is:
   `python -m pytest --cov=paper_chaser_mcp --cov-report=term-missing --cov-fail-under=85`
-  => `630 passed`, total coverage `85.00%`.
+  => `655 passed`, total coverage `85.09%`.
 
 ## Start Here
 
@@ -43,6 +45,9 @@ Read these in order before making behavior or guidance changes:
 3. `docs/guided-reset-migration-note.md`
 4. `.github/copilot-instructions.md`
 5. This file: `docs/agent-handoff.md`
+
+If you are changing guided recovery, input normalization, or result-state metadata,
+also read `docs/guided-smart-robustness.md`.
 
 For release work, also read `docs/release-publishing-plan.md`.
 
@@ -66,8 +71,8 @@ gh aw compile test-paper-chaser --dir .github/workflows
 - `research`: default entry point for discovery, literature review, known-item
   recovery, citation repair, and regulatory routing.
 - `follow_up_research`: one grounded follow-up over a saved `searchSessionId`.
-- `resolve_reference`: DOI/arXiv/URL/citation/reference cleanup.
-- `inspect_source`: per-source provenance and trust inspection.
+- `resolve_reference`: DOI/arXiv/URL/citation/reference cleanup with exact identifier normalization before fuzzy recovery.
+- `inspect_source`: per-source provenance and trust inspection; omitted `searchSessionId` only works when one compatible saved session exists.
 - `get_runtime_status`: profile/provider/runtime sanity check.
 
 ### Expert profile

--- a/docs/golden-paths.md
+++ b/docs/golden-paths.md
@@ -67,6 +67,7 @@ research(query="retrieval-augmented generation for coding agents", limit=5)
 1. Use `follow_up_research` with `searchSessionId` from `research`.
 2. Gate on `answerStatus` before trusting the answer body.
 3. If not answered, follow `nextActions` and inspect source-level evidence.
+4. If `searchSessionId` is omitted, expect inference only when exactly one compatible saved session exists.
 
 **Example**
 
@@ -89,6 +90,7 @@ follow_up_research(searchSessionId="...", question="What evaluation tradeoffs sh
    `resolved`, `multiple_candidates`, `no_match`, `regulatory_primary_source`.
 3. Use `bestMatch`/`alternatives` and `nextActions` to decide whether to pivot
    back into `research` with a stronger anchor.
+4. Exact DOI, arXiv, and supported paper URLs should resolve as direct anchors before fuzzy recovery.
 
 ### 4. Source-level audit (`inspect_source`)
 
@@ -96,6 +98,7 @@ follow_up_research(searchSessionId="...", question="What evaluation tradeoffs sh
    outputs.
 2. Review provenance and trust state before citing.
 3. Follow direct-read recommendations for primary sources.
+4. If `searchSessionId` is omitted and more than one compatible session exists, provide it explicitly instead of expecting newest-session rebinding.
 
 **Success signals**
 
@@ -108,6 +111,7 @@ follow_up_research(searchSessionId="...", question="What evaluation tradeoffs sh
 2. Check `runtimeSummary.effectiveProfile`, transport, smart provider status,
    provider visibility, and warnings.
 3. Use this before troubleshooting with expert diagnostics.
+4. Interpret `configuredSmartProvider` as the configured bundle and `activeSmartProvider` as the latest effective execution path, including deterministic fallback.
 
 ## Regulatory-specific guided behavior
 

--- a/docs/guided-reset-migration-note.md
+++ b/docs/guided-reset-migration-note.md
@@ -28,8 +28,10 @@ environments even though the server still supports those tools in expert mode.
 - Keep `PAPER_CHASER_TOOL_PROFILE=guided` (or omit it).
 - Update clients to start from `research`.
 - Reuse `searchSessionId` with `follow_up_research`.
+- If `searchSessionId` is omitted, guided follow-up and source inspection infer it only when one compatible saved session exists.
 - Use `inspect_source` for provenance and direct-read follow-through.
 - Use `resolve_reference` for citation/identifier normalization.
+- Expect exact DOI, arXiv, and supported paper URLs to resolve before fuzzy citation repair.
 - Treat `abstained` and `needs_disambiguation` as intended safe outcomes.
 
 ### 2) Opt Into Expert Surface
@@ -54,6 +56,7 @@ environments even though the server still supports those tools in expert mode.
   - `effectiveProfile`
   - `configuredSmartProvider`
   - `activeSmartProvider`
+  - where `activeSmartProvider` means the latest effective execution path, including deterministic fallback
   - internally consistent active/disabled provider sets.
 
 ## Release-Readiness Checks

--- a/docs/guided-smart-robustness.md
+++ b/docs/guided-smart-robustness.md
@@ -1,0 +1,84 @@
+# Guided And Smart Robustness Notes
+
+This document captures the server-side behaviors added to make guided and smart workflows more tolerant of imperfect client inputs and more explicit about internal recovery.
+
+## Goals
+
+- Recover internally before abstaining.
+- Avoid assuming perfect `searchSessionId` and `sourceId` handling by clients.
+- Expose machine-readable routing, recovery, and result-state metadata.
+- Keep deterministic heuristics as guardrails rather than dominant routing logic.
+
+## Guided Dispatch
+
+The guided wrappers in `paper_chaser_mcp/dispatch.py` now normalize and repair incoming arguments before validation.
+
+- `research` normalizes whitespace, strips common wrapper phrases, and canonicalizes citation-like surfaces where it is safe.
+- `follow_up_research` and `inspect_source` normalize alternate session/source field names and can recover only when one compatible saved session is uniquely identifiable.
+- Guided responses now include:
+  - `resultState`
+  - `inputNormalization`
+  - `machineFailure` when the smart runtime returns an invalid payload or raises unexpectedly
+
+### Source Resolution
+
+`inspect_source` accepts more than exact `sourceId` matches.
+
+- exact `sourceId`
+- case-folded exact matches
+- canonical URL / citation text matches
+- session-local index aliases such as `source-1`
+- unique partial title matches
+
+## Smart Metadata
+
+`paper_chaser_mcp/agentic/models.py` and `paper_chaser_mcp/agentic/planner.py` now support richer planning metadata.
+
+- `intentCandidates`
+- `secondaryIntents`
+- `routingConfidence`
+- `intentRationale`
+- `recoveryAttempted`
+- `recoveryPath`
+- `recoveryReason`
+- `stoppedRecoveryBecause`
+- `anchorType`
+- `anchorStrength`
+- `anchoredSubject`
+- `normalizationWarnings`
+- `repairedInputs`
+
+This metadata is intended for downstream clients and debugging tools. It should be treated as additive contract, not a replacement for the main result payload.
+
+## Recovery Semantics
+
+Smart search recovery is explicit rather than implicit.
+
+- empty regulatory routes can recover into semantic known-item resolution
+- empty regulatory routes can recover into literature review when the query supports it
+- known-item resolution can widen into broader candidate retrieval instead of hard failing
+
+Each recovery path should annotate strategy metadata so clients can tell:
+
+- what route won
+- whether fallback was used
+- why fallback happened
+- which anchor the server trusted most
+
+## Session Registry
+
+`paper_chaser_mcp/agentic/workspace.py` remains the source of truth for saved result sets.
+
+- sessions are still TTL-bound
+- saved records still carry payload, metadata, indexed papers, authors, and trace events
+- the registry now exposes active records ordered by recency so dispatch can make safe session-inference decisions
+
+## Testing Expectations
+
+Focused regressions should cover:
+
+- optional `searchSessionId` for guided follow-up and source inspection
+- source alias resolution
+- input normalization metadata
+- smart recovery provenance and anchor metadata
+- mixed and degraded flows that still return actionable result state

--- a/paper_chaser_mcp/agentic/graphs.py
+++ b/paper_chaser_mcp/agentic/graphs.py
@@ -46,8 +46,10 @@ from .models import (
     EvidenceItem,
     GraphEdge,
     GraphNode,
+    IntentLabel,
     LandscapeResponse,
     LandscapeTheme,
+    PlannerDecision,
     ResearchGraphResponse,
     ScoreBreakdown,
     SearchStrategyMetadata,
@@ -60,6 +62,7 @@ from .planner import (
     classify_query,
     combine_variants,
     dedupe_variants,
+    detect_literature_intent,
     grounded_expansion_candidates,
     query_facets,
     query_terms,
@@ -428,6 +431,7 @@ class AgenticRuntime:
             request_outcomes=provider_outcomes,
             request_id=request_id,
         )
+        normalization_warnings, repaired_inputs = _normalization_metadata(query, normalized_query)
         _finish_stage("planning", planning_started)
         await self._emit_smart_search_status(
             ctx=ctx,
@@ -445,7 +449,7 @@ class AgenticRuntime:
             return await self._search_known_item(
                 query=normalized_query,
                 limit=limit,
-                planner_intent=planner.intent,
+                planner=planner,
                 provider_plan=planner.provider_plan or None,
                 provider_budget=budget_state,
                 search_session_id=search_session_id,
@@ -454,20 +458,130 @@ class AgenticRuntime:
                 include_enrichment=include_enrichment,
                 provider_outcomes=provider_outcomes,
                 stage_timings_ms=stage_timings_ms,
+                normalization_warnings=normalization_warnings,
+                repaired_inputs=repaired_inputs,
                 ctx=ctx,
             )
         if planner.intent == "regulatory":
-            return await self._search_regulatory(
+            regulatory_result = await self._search_regulatory(
                 query=normalized_query,
                 limit=limit,
                 planner_intent=planner.intent,
+                planner=planner,
                 search_session_id=search_session_id,
                 latency_profile=latency_profile,
                 request_id=request_id,
                 provider_outcomes=provider_outcomes,
                 stage_timings_ms=stage_timings_ms,
+                normalization_warnings=normalization_warnings,
+                repaired_inputs=repaired_inputs,
                 ctx=ctx,
             )
+            if regulatory_result.get("structuredSources"):
+                return regulatory_result
+
+            recovered_anchor, _ = await self._resolve_known_item(normalized_query)
+            if recovered_anchor is not None:
+                await self._emit_smart_search_status(
+                    ctx=ctx,
+                    request_id=request_id,
+                    progress=22,
+                    message="Recovering from empty regulatory route",
+                    detail=(
+                        "Regulatory retrieval returned no on-topic sources; retrying the same query as a "
+                        "semantic known-item recovery."
+                    ),
+                )
+                recovered = await self._search_known_item(
+                    query=normalized_query,
+                    limit=limit,
+                    planner=planner.model_copy(
+                        update={
+                            "intent": "known_item",
+                            "intent_source": "fallback_recovery",
+                            "intent_confidence": "medium",
+                        }
+                    ),
+                    provider_plan=planner.provider_plan or None,
+                    provider_budget=budget_state,
+                    search_session_id=search_session_id,
+                    latency_profile=latency_profile,
+                    request_id=request_id,
+                    include_enrichment=include_enrichment,
+                    provider_outcomes=provider_outcomes,
+                    stage_timings_ms=stage_timings_ms,
+                    normalization_warnings=normalization_warnings,
+                    repaired_inputs=repaired_inputs,
+                    ctx=ctx,
+                )
+                strategy_metadata = recovered.get("strategyMetadata") if isinstance(recovered, dict) else None
+                if isinstance(strategy_metadata, dict):
+                    warnings = list(strategy_metadata.get("driftWarnings") or [])
+                    warnings.append(
+                        "Regulatory routing returned no on-topic sources, so the server retried "
+                        "with semantic known-item recovery."
+                    )
+                    strategy_metadata["intent"] = "known_item"
+                    strategy_metadata["intentSource"] = "fallback_recovery"
+                    strategy_metadata["intentConfidence"] = "medium"
+                    strategy_metadata["recoveryAttempted"] = True
+                    strategy_metadata["recoveryPath"] = ["regulatory", "known_item"]
+                    strategy_metadata["recoveryReason"] = "Regulatory retrieval returned no on-topic sources."
+                    strategy_metadata["anchoredSubject"] = (
+                        recovered.get("results", [{}])[0].get("paper", {}).get("title") or normalized_query
+                    )
+                    strategy_metadata["bestNextInternalAction"] = "get_paper_details"
+                    strategy_metadata["driftWarnings"] = list(dict.fromkeys(warnings))
+                return recovered
+
+            if not detect_literature_intent(query, focus):
+                strategy_metadata = (
+                    regulatory_result.get("strategyMetadata") if isinstance(regulatory_result, dict) else None
+                )
+                if isinstance(strategy_metadata, dict):
+                    strategy_metadata["stoppedRecoveryBecause"] = (
+                        "No adjacent literature intent was detected after the regulatory route returned empty."
+                    )
+                return regulatory_result
+
+            await self._emit_smart_search_status(
+                ctx=ctx,
+                request_id=request_id,
+                progress=22,
+                message="Recovering from empty regulatory route",
+                detail=(
+                    "Regulatory retrieval returned no on-topic sources; retrying "
+                    f"'{_truncate_text(normalized_query, limit=96)}' "
+                    "as a literature review."
+                ),
+            )
+            recovered = await self.search_papers_smart(
+                query=query,
+                limit=limit,
+                search_session_id=search_session_id,
+                mode="review",
+                year=year,
+                venue=venue,
+                focus=focus,
+                latency_profile=latency_profile,
+                provider_budget=provider_budget,
+                include_enrichment=include_enrichment,
+                ctx=ctx,
+            )
+            strategy_metadata = recovered.get("strategyMetadata") if isinstance(recovered, dict) else None
+            if isinstance(strategy_metadata, dict):
+                warnings = list(strategy_metadata.get("driftWarnings") or [])
+                warnings.append(
+                    "Regulatory routing returned no on-topic sources, so the server "
+                    "retried with a literature-oriented recovery path."
+                )
+                strategy_metadata["driftWarnings"] = list(dict.fromkeys(warnings))
+                strategy_metadata["intentSource"] = "fallback_recovery"
+                strategy_metadata["intentConfidence"] = "medium"
+                strategy_metadata["recoveryAttempted"] = True
+                strategy_metadata["recoveryPath"] = ["regulatory", "review"]
+                strategy_metadata["recoveryReason"] = "Regulatory retrieval returned no on-topic sources."
+            return recovered
 
         await self._emit_smart_search_status(
             ctx=ctx,
@@ -814,6 +928,12 @@ class AgenticRuntime:
         )
         strategy_metadata = SearchStrategyMetadata(
             intent=planner.intent,
+            intentSource=planner.intent_source,
+            intentConfidence=planner.intent_confidence,
+            intentCandidates=planner.intent_candidates,
+            secondaryIntents=planner.secondary_intents,
+            routingConfidence=planner.routing_confidence,
+            intentRationale=planner.intent_rationale,
             latencyProfile=latency_profile,
             normalizedQuery=normalized_query,
             queryVariantsTried=[candidate.variant for candidate in variants],
@@ -830,6 +950,14 @@ class AgenticRuntime:
             providerBudgetApplied=budget_state.to_dict() if budget_state else {},
             providerOutcomes=provider_outcomes,
             stageTimingsMs=stage_timings_ms,
+            recoveryAttempted=False,
+            recoveryPath=[planner.intent],
+            anchorType="query_concepts",
+            anchorStrength=planner.routing_confidence,
+            anchoredSubject=(planner.candidate_concepts[0] if planner.candidate_concepts else normalized_query),
+            normalizationWarnings=normalization_warnings,
+            repairedInputs=repaired_inputs,
+            bestNextInternalAction=("ask_result_set" if filtered_ranked else "search_papers_smart"),
             **provider_selection,
         )
 
@@ -914,6 +1042,13 @@ class AgenticRuntime:
                 provider_outcomes=provider_outcomes,
                 fallback_attempted=bool(provider_fallback_warnings or rejected_speculative),
             ),
+            resultStatus=("succeeded" if smart_hits else "partial"),
+            hasInspectableSources=_has_inspectable_sources(source_records),
+            bestNextInternalAction=_best_next_internal_action(
+                intent=planner.intent,
+                has_sources=bool(source_records),
+                result_status=("succeeded" if smart_hits else "partial"),
+            ),
         )
         if provider_fallback_warnings:
             response.agent_hints.warnings.extend(provider_fallback_warnings)
@@ -941,7 +1076,7 @@ class AgenticRuntime:
             dump_jsonable(response),
             record.search_session_id,
         )
-        final_response_dict = dump_jsonable(response)
+        final_response_dict = self._workspace_registry.attach_source_aliases(dump_jsonable(response))
         record.payload = final_response_dict
         record.metadata["strategyMetadata"] = final_response_dict["strategyMetadata"]
         if self._config.enable_trace_log:
@@ -1683,12 +1818,15 @@ class AgenticRuntime:
         *,
         query: str,
         limit: int,
-        planner_intent: str,
+        planner_intent: IntentLabel,
+        planner: PlannerDecision,
         search_session_id: str | None,
         latency_profile: LatencyProfile,
         request_id: str,
         provider_outcomes: list[dict[str, Any]],
         stage_timings_ms: dict[str, int],
+        normalization_warnings: list[str],
+        repaired_inputs: dict[str, Any],
         ctx: Context | None,
     ) -> dict[str, Any]:
         attempted: list[str] = []
@@ -1934,6 +2072,72 @@ class AgenticRuntime:
                     }
                 )
 
+        if (
+            self._enable_govinfo_cfr
+            and self._govinfo_client is not None
+            and not govinfo_matched
+            and not federal_register_matched
+        ):
+            if "govinfo" not in attempted:
+                attempted.append("govinfo")
+            started = time.perf_counter()
+            try:
+                govinfo_search = await self._govinfo_client.search_federal_register_documents(
+                    query=fr_query,
+                    limit=min(max(limit, 5), 10),
+                )
+                stage_timings_ms["regulatoryGovInfoSearch"] = int((time.perf_counter() - started) * 1000)
+                documents = list(govinfo_search.get("data") or [])
+                if documents:
+                    succeeded.append("govinfo")
+                    for document in documents[:limit]:
+                        if not isinstance(document, dict):
+                            continue
+                        if not _regulatory_document_matches_subject(
+                            document,
+                            subject_terms=anchored_subject_terms,
+                            cfr_citation=cfr_citation,
+                        ):
+                            continue
+                        structured_sources.append(
+                            _source_record_from_regulatory_document(
+                                document,
+                                provider="govinfo",
+                                topical_relevance="on_topic",
+                            )
+                        )
+                        govinfo_matched = True
+                        timeline_events.append(
+                            RegulatoryTimelineEvent(
+                                eventType="rulemaking_history",
+                                eventDate=document.get("publicationDate"),
+                                title=str(document.get("title") or document.get("citation") or "GovInfo document"),
+                                citation=str(document.get("citation") or document.get("documentNumber") or "") or None,
+                                canonicalUrl=document.get("sourceUrl"),
+                                provider="govinfo",
+                                verificationStatus=cast(
+                                    VerificationStatus,
+                                    document.get("verificationStatus") or "verified_metadata",
+                                ),
+                                note=str(
+                                    document.get("note") or "GovInfo Federal Register primary-source recovery hit."
+                                ),
+                            )
+                        )
+                else:
+                    zero_results.append("govinfo")
+            except Exception as exc:
+                stage_timings_ms["regulatoryGovInfoSearch"] = int((time.perf_counter() - started) * 1000)
+                failed.append("govinfo")
+                provider_outcomes.append(
+                    {
+                        "provider": "govinfo",
+                        "endpoint": "search_federal_register_documents",
+                        "statusBucket": "provider_error",
+                        "error": str(exc),
+                    }
+                )
+
         structured_sources = _dedupe_structured_sources(structured_sources)
         timeline_events = sorted(timeline_events, key=lambda event: str(event.event_date or "9999-99-99"))
         if not timeline_events:
@@ -2003,8 +2207,31 @@ class AgenticRuntime:
                 ),
                 recommendedNextAction="review_partial_results",
             )
+        result_status = (
+            "succeeded"
+            if structured_sources and current_text_satisfied and failure_summary is None
+            else ("partial" if structured_sources else "abstained")
+        )
+        anchor_type = (
+            "cfr_citation"
+            if cfr_request
+            else (
+                "ecos_species"
+                if species_hit is not None
+                else ("regulatory_subject_terms" if anchored_subject_terms else None)
+            )
+        )
+        anchor_strength: Literal["high", "medium", "low"] | None = (
+            "high" if cfr_request or species_hit is not None else ("medium" if anchored_subject_terms else None)
+        )
         strategy_metadata = SearchStrategyMetadata(
             intent=planner_intent,
+            intentSource=planner.intent_source,
+            intentConfidence=planner.intent_confidence,
+            intentCandidates=planner.intent_candidates,
+            secondaryIntents=planner.secondary_intents,
+            routingConfidence=planner.routing_confidence,
+            intentRationale=planner.intent_rationale,
             latencyProfile=latency_profile,
             normalizedQuery=query,
             queryVariantsTried=[query],
@@ -2018,6 +2245,18 @@ class AgenticRuntime:
             providerBudgetApplied={},
             providerOutcomes=provider_outcomes,
             stageTimingsMs=stage_timings_ms,
+            recoveryAttempted=False,
+            recoveryPath=[planner_intent],
+            anchorType=anchor_type,
+            anchorStrength=anchor_strength,
+            anchoredSubject=subject or query,
+            normalizationWarnings=normalization_warnings,
+            repairedInputs=repaired_inputs,
+            bestNextInternalAction=_best_next_internal_action(
+                intent=planner_intent,
+                has_sources=bool(structured_sources),
+                result_status=result_status,
+            ),
             **provider_selection,
         )
         response = SmartSearchResponse(
@@ -2060,6 +2299,13 @@ class AgenticRuntime:
                 events=timeline_events,
                 evidenceGaps=evidence_gaps,
             ),
+            resultStatus=result_status,
+            hasInspectableSources=_has_inspectable_sources(structured_sources),
+            bestNextInternalAction=_best_next_internal_action(
+                intent=planner_intent,
+                has_sources=bool(structured_sources),
+                result_status=result_status,
+            ),
         )
         record = await self._workspace_registry.asave_result_set(
             source_tool="search_papers_smart",
@@ -2074,7 +2320,7 @@ class AgenticRuntime:
             dump_jsonable(response),
             record.search_session_id,
         )
-        final_response_dict = dump_jsonable(response)
+        final_response_dict = self._workspace_registry.attach_source_aliases(dump_jsonable(response))
         record.payload = final_response_dict
         record.metadata["strategyMetadata"] = final_response_dict["strategyMetadata"]
         await self._emit_smart_search_status(
@@ -2091,7 +2337,7 @@ class AgenticRuntime:
         *,
         query: str,
         limit: int,
-        planner_intent: str,
+        planner: PlannerDecision,
         provider_plan: list[str] | None,
         provider_budget: ProviderBudgetState | None,
         search_session_id: str | None,
@@ -2100,6 +2346,8 @@ class AgenticRuntime:
         include_enrichment: bool,
         provider_outcomes: list[dict[str, Any]],
         stage_timings_ms: dict[str, int],
+        normalization_warnings: list[str],
+        repaired_inputs: dict[str, Any],
         ctx: Context | None,
     ) -> dict[str, Any]:
         await self._emit_smart_search_status(
@@ -2126,7 +2374,7 @@ class AgenticRuntime:
             return await self._fallback_known_item_search(
                 query=query,
                 limit=limit,
-                planner_intent=planner_intent,
+                planner=planner,
                 provider_plan=provider_plan,
                 provider_budget=provider_budget,
                 search_session_id=search_session_id,
@@ -2135,6 +2383,8 @@ class AgenticRuntime:
                 include_enrichment=include_enrichment,
                 provider_outcomes=provider_outcomes,
                 stage_timings_ms=stage_timings_ms,
+                normalization_warnings=normalization_warnings,
+                repaired_inputs=repaired_inputs,
                 ctx=ctx,
             )
         if include_enrichment and self._enrichment_service is not None:
@@ -2183,7 +2433,13 @@ class AgenticRuntime:
             provider_outcomes=provider_outcomes,
         )
         strategy_metadata = SearchStrategyMetadata(
-            intent=planner_intent,
+            intent=planner.intent,
+            intentSource=planner.intent_source,
+            intentConfidence=planner.intent_confidence,
+            intentCandidates=planner.intent_candidates,
+            secondaryIntents=planner.secondary_intents,
+            routingConfidence=planner.routing_confidence,
+            intentRationale=planner.intent_rationale,
             latencyProfile=latency_profile,
             normalizedQuery=query,
             queryVariantsTried=[query],
@@ -2196,14 +2452,20 @@ class AgenticRuntime:
             driftWarnings=(
                 []
                 if resolution_strategy == "citation_resolution"
-                else [
-                    "Known-item fallback used title-style recovery; verify the anchor before treating it as canonical."
-                ]
+                else [_known_item_recovery_warning(resolution_strategy)]
             )
             + provider_fallback_warnings,
             providerBudgetApplied=(provider_budget.to_dict() if provider_budget else {}),
             providerOutcomes=provider_outcomes,
             stageTimingsMs=stage_timings_ms,
+            recoveryAttempted=planner.intent_source == "fallback_recovery",
+            recoveryPath=[planner.intent],
+            anchorType=resolution_strategy,
+            anchorStrength=_anchor_strength_for_resolution(resolution_strategy),
+            anchoredSubject=str(known_item.get("title") or query),
+            normalizationWarnings=normalization_warnings,
+            repairedInputs=repaired_inputs,
+            bestNextInternalAction="get_paper_details",
             **provider_selection,
         )
         response = SmartSearchResponse(
@@ -2218,6 +2480,9 @@ class AgenticRuntime:
                 {"paperId": known_item.get("paperId")},
             ),
             resourceUris=[],
+            resultStatus="succeeded",
+            hasInspectableSources=True,
+            bestNextInternalAction="get_paper_details",
         )
         if provider_fallback_warnings:
             response.agent_hints.warnings.extend(provider_fallback_warnings)
@@ -2244,7 +2509,7 @@ class AgenticRuntime:
             {"results": [{"paper": known_item}]},
             record.search_session_id,
         )
-        final_response_dict = dump_jsonable(response)
+        final_response_dict = self._workspace_registry.attach_source_aliases(dump_jsonable(response))
         record.payload = final_response_dict
         record.metadata["strategyMetadata"] = final_response_dict["strategyMetadata"]
         await self._emit_smart_search_status(
@@ -2322,7 +2587,7 @@ class AgenticRuntime:
         *,
         query: str,
         limit: int,
-        planner_intent: str,
+        planner: PlannerDecision,
         provider_plan: list[str] | None,
         provider_budget: ProviderBudgetState | None,
         search_session_id: str | None,
@@ -2331,6 +2596,8 @@ class AgenticRuntime:
         include_enrichment: bool,
         provider_outcomes: list[dict[str, Any]],
         stage_timings_ms: dict[str, int],
+        normalization_warnings: list[str],
+        repaired_inputs: dict[str, Any],
         ctx: Context | None,
     ) -> dict[str, Any]:
         profile_settings = self._config.latency_profile_settings(latency_profile)
@@ -2339,7 +2606,7 @@ class AgenticRuntime:
         batch = await retrieve_variant(
             variant=query,
             variant_source="from_input",
-            intent=planner_intent,
+            intent=planner.intent,
             year=None,
             venue=None,
             enable_core=self._enable_core,
@@ -2411,7 +2678,13 @@ class AgenticRuntime:
             provider_outcomes=provider_outcomes,
         )
         strategy_metadata = SearchStrategyMetadata(
-            intent=planner_intent,
+            intent=planner.intent,
+            intentSource=planner.intent_source,
+            intentConfidence=planner.intent_confidence,
+            intentCandidates=planner.intent_candidates,
+            secondaryIntents=planner.secondary_intents,
+            routingConfidence=planner.routing_confidence,
+            intentRationale=planner.intent_rationale,
             latencyProfile=latency_profile,
             normalizedQuery=query,
             queryVariantsTried=[query],
@@ -2429,6 +2702,15 @@ class AgenticRuntime:
             providerBudgetApplied=(provider_budget.to_dict() if provider_budget else {}),
             providerOutcomes=provider_outcomes,
             stageTimingsMs=stage_timings_ms,
+            recoveryAttempted=True,
+            recoveryPath=["known_item", "discovery"],
+            recoveryReason="No exact known-item anchor was confirmed.",
+            anchorType="candidate_set",
+            anchorStrength="low",
+            anchoredSubject=query,
+            normalizationWarnings=normalization_warnings,
+            repairedInputs=repaired_inputs,
+            bestNextInternalAction=("ask_result_set" if smart_hits else "search_papers_smart"),
             **provider_selection,
         )
         response = SmartSearchResponse(
@@ -2445,6 +2727,13 @@ class AgenticRuntime:
                 {"brokerMetadata": {"resultQuality": "low_relevance" if not smart_hits else "unknown"}},
             ),
             resourceUris=[],
+            resultStatus=("partial" if smart_hits else "abstained"),
+            hasInspectableSources=bool(smart_hits),
+            bestNextInternalAction=_best_next_internal_action(
+                intent=planner.intent,
+                has_sources=bool(smart_hits),
+                result_status=("partial" if smart_hits else "abstained"),
+            ),
         )
         if provider_fallback_warnings:
             response.agent_hints.warnings.extend(provider_fallback_warnings)
@@ -2461,7 +2750,7 @@ class AgenticRuntime:
             {"results": [{"paper": hit.paper.model_dump(by_alias=True)} for hit in smart_hits]},
             record.search_session_id,
         )
-        final_response_dict = dump_jsonable(response)
+        final_response_dict = self._workspace_registry.attach_source_aliases(dump_jsonable(response))
         record.payload = final_response_dict
         record.metadata["strategyMetadata"] = final_response_dict["strategyMetadata"]
         await self._emit_smart_search_status(
@@ -2722,7 +3011,11 @@ def _source_record_from_regulatory_document(
             else "Federal Register primary-source discovery hit"
         )
     elif provider == "govinfo":
-        note = "Authoritative CFR text"
+        note = str(
+            document.get("note")
+            or ("Authoritative CFR text" if document.get("markdown") else "GovInfo primary-source discovery hit")
+        )
+    has_full_text = bool(document.get("markdown") or document.get("contentSource"))
     return StructuredSourceRecord(
         sourceId=source_id,
         title=title,
@@ -2732,21 +3025,15 @@ def _source_record_from_regulatory_document(
             document.get("verificationStatus")
             or ("verified_primary_source" if provider == "govinfo" else "verified_metadata")
         ),
-        accessStatus=(
-            "full_text_verified" if provider == "govinfo" or document.get("markdown") else "access_unverified"
-        ),
+        accessStatus=("full_text_verified" if has_full_text else "access_unverified"),
         confidence="high" if provider == "govinfo" else "medium",
         topicalRelevance=topical_relevance,
         isPrimarySource=True,
         canonicalUrl=canonical_url,
         retrievedUrl=canonical_url,
-        fullTextObserved=bool(document.get("markdown") or provider == "govinfo"),
+        fullTextObserved=has_full_text,
         abstractObserved=False,
-        openAccessRoute=(
-            "non_oa_or_unconfirmed"
-            if (provider == "govinfo" or document.get("markdown") or canonical_url)
-            else "unknown"
-        ),
+        openAccessRoute=("non_oa_or_unconfirmed" if (has_full_text or canonical_url) else "unknown"),
         citationText=citation,
         citation=_citation_record_from_regulatory_document(
             document,
@@ -3344,6 +3631,59 @@ def _known_item_title_similarity(query: str, title: str) -> float:
     title_tokens = {token for token in normalized_title.split() if len(token) >= 3 and not token.isdigit()}
     overlap = len(query_tokens & title_tokens) / len(query_tokens) if query_tokens else 0.0
     return max(SequenceMatcher(None, normalized_query, normalized_title).ratio(), overlap)
+
+
+def _normalization_metadata(raw_query: str, normalized_query: str) -> tuple[list[str], dict[str, Any]]:
+    raw_text = str(raw_query or "")
+    normalized_text = str(normalized_query or "")
+    if raw_text == normalized_text:
+        return [], {}
+    return (
+        ["The server normalized the incoming query before routing it."],
+        {
+            "query": {
+                "from": raw_text,
+                "to": normalized_text,
+            }
+        },
+    )
+
+
+def _anchor_strength_for_resolution(resolution_strategy: str) -> Literal["high", "medium", "low"]:
+    if resolution_strategy == "citation_resolution":
+        return "high"
+    if resolution_strategy in {"semantic_title_match", "openalex_autocomplete"}:
+        return "medium"
+    return "low"
+
+
+def _known_item_recovery_warning(resolution_strategy: str) -> str:
+    if resolution_strategy == "semantic_title_match":
+        return "Known-item recovery used a semantic title match; verify the anchor before treating it as canonical."
+    if resolution_strategy == "openalex_autocomplete":
+        return "Known-item recovery used OpenAlex autocomplete; verify the anchor before treating it as canonical."
+    if resolution_strategy == "openalex_search":
+        return "Known-item recovery used OpenAlex search; verify the anchor before treating it as canonical."
+    return "Known-item fallback used title-style recovery; verify the anchor before treating it as canonical."
+
+
+def _has_inspectable_sources(records: list[StructuredSourceRecord]) -> bool:
+    return any(
+        bool(record.canonical_url or record.retrieved_url or record.full_text_observed or record.abstract_observed)
+        for record in records
+    )
+
+
+def _best_next_internal_action(*, intent: str, has_sources: bool, result_status: str) -> str:
+    if intent == "known_item":
+        return "get_paper_details"
+    if intent == "regulatory":
+        return "inspect_source" if has_sources else "search_papers_smart"
+    if has_sources:
+        return "ask_result_set"
+    if result_status == "partial":
+        return "search_papers_smart"
+    return "resolve_reference"
 
 
 def _top_terms_for_cluster(papers: list[dict[str, Any]]) -> list[str]:

--- a/paper_chaser_mcp/agentic/models.py
+++ b/paper_chaser_mcp/agentic/models.py
@@ -9,6 +9,15 @@ from pydantic import Field
 from ..models.common import ApiModel, CitationRecord, CoverageSummary, FailureSummary, OpenAccessRoute, Paper
 from ..models.regulations import RegulatoryTimeline
 
+IntentLabel = Literal[
+    "discovery",
+    "review",
+    "known_item",
+    "author",
+    "citation",
+    "regulatory",
+]
+
 
 class AgentHints(ApiModel):
     """Agent-facing next-step cues included on read-tool responses."""
@@ -52,10 +61,46 @@ class StructuredToolError(ApiModel):
     )
 
 
+class IntentCandidate(ApiModel):
+    """One plausible intent considered during planning."""
+
+    intent: IntentLabel
+    confidence: Literal["high", "medium", "low"] = "low"
+    source: Literal["explicit", "planner", "heuristic", "hybrid", "fallback"] = "planner"
+    rationale: str = ""
+
+
 class SearchStrategyMetadata(ApiModel):
     """Transparent search-planning metadata surfaced to external agents."""
 
-    intent: str = "discovery"
+    intent: IntentLabel = "discovery"
+    intent_source: Literal[
+        "explicit",
+        "planner",
+        "heuristic_override",
+        "hybrid_agreement",
+        "fallback_recovery",
+    ] = Field(default="planner", alias="intentSource")
+    intent_confidence: Literal["high", "medium", "low"] = Field(
+        default="medium",
+        alias="intentConfidence",
+    )
+    intent_candidates: list[IntentCandidate] = Field(
+        default_factory=list,
+        alias="intentCandidates",
+    )
+    secondary_intents: list[IntentLabel] = Field(
+        default_factory=list,
+        alias="secondaryIntents",
+    )
+    routing_confidence: Literal["high", "medium", "low"] = Field(
+        default="medium",
+        alias="routingConfidence",
+    )
+    intent_rationale: str = Field(
+        default="",
+        alias="intentRationale",
+    )
     latency_profile: Literal["fast", "balanced", "deep"] = Field(
         default="balanced",
         alias="latencyProfile",
@@ -120,6 +165,42 @@ class SearchStrategyMetadata(ApiModel):
         default_factory=list,
         alias="driftWarnings",
     )
+    recovery_attempted: bool = Field(
+        default=False,
+        alias="recoveryAttempted",
+    )
+    recovery_path: list[str] = Field(
+        default_factory=list,
+        alias="recoveryPath",
+    )
+    recovery_reason: str | None = Field(
+        default=None,
+        alias="recoveryReason",
+    )
+    stopped_recovery_because: str | None = Field(
+        default=None,
+        alias="stoppedRecoveryBecause",
+    )
+    anchor_type: str | None = Field(
+        default=None,
+        alias="anchorType",
+    )
+    anchor_strength: Literal["high", "medium", "low"] | None = Field(
+        default=None,
+        alias="anchorStrength",
+    )
+    anchored_subject: str | None = Field(
+        default=None,
+        alias="anchoredSubject",
+    )
+    normalization_warnings: list[str] = Field(
+        default_factory=list,
+        alias="normalizationWarnings",
+    )
+    repaired_inputs: dict[str, Any] = Field(
+        default_factory=dict,
+        alias="repairedInputs",
+    )
     provider_budget_applied: dict[str, Any] = Field(
         default_factory=dict,
         alias="providerBudgetApplied",
@@ -132,12 +213,17 @@ class SearchStrategyMetadata(ApiModel):
         default_factory=dict,
         alias="stageTimingsMs",
     )
+    best_next_internal_action: str | None = Field(
+        default=None,
+        alias="bestNextInternalAction",
+    )
 
 
 class StructuredSourceRecord(ApiModel):
     """Trust-graded source record for smart responses."""
 
     source_id: str | None = Field(default=None, alias="sourceId")
+    source_alias: str | None = Field(default=None, alias="sourceAlias")
     title: str | None = None
     provider: str | None = None
     source_type: str | None = Field(default=None, alias="sourceType")
@@ -259,6 +345,9 @@ class SmartSearchResponse(ApiModel):
     failure_summary: FailureSummary | None = Field(default=None, alias="failureSummary")
     regulatory_timeline: RegulatoryTimeline | None = Field(default=None, alias="regulatoryTimeline")
     clarification: Clarification | None = None
+    result_status: str = Field(default="succeeded", alias="resultStatus")
+    has_inspectable_sources: bool = Field(default=False, alias="hasInspectableSources")
+    best_next_internal_action: str = Field(default="follow_up_research", alias="bestNextInternalAction")
 
 
 class EvidenceItem(ApiModel):
@@ -387,14 +476,34 @@ class ResearchGraphResponse(ApiModel):
 class PlannerDecision(ApiModel):
     """Planner output for smart search orchestration."""
 
-    intent: Literal[
-        "discovery",
-        "review",
-        "known_item",
-        "author",
-        "citation",
-        "regulatory",
-    ] = "discovery"
+    intent: IntentLabel = "discovery"
+    intent_source: Literal[
+        "explicit",
+        "planner",
+        "heuristic_override",
+        "hybrid_agreement",
+        "fallback_recovery",
+    ] = Field(default="planner", alias="intentSource")
+    intent_confidence: Literal["high", "medium", "low"] = Field(
+        default="medium",
+        alias="intentConfidence",
+    )
+    intent_candidates: list[IntentCandidate] = Field(
+        default_factory=list,
+        alias="intentCandidates",
+    )
+    secondary_intents: list[IntentLabel] = Field(
+        default_factory=list,
+        alias="secondaryIntents",
+    )
+    routing_confidence: Literal["high", "medium", "low"] = Field(
+        default="medium",
+        alias="routingConfidence",
+    )
+    intent_rationale: str = Field(
+        default="",
+        alias="intentRationale",
+    )
     constraints: dict[str, str] = Field(default_factory=dict)
     seed_identifiers: list[str] = Field(
         default_factory=list,

--- a/paper_chaser_mcp/agentic/planner.py
+++ b/paper_chaser_mcp/agentic/planner.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 from ..citation_repair import looks_like_citation_query
 from .config import AgenticConfig
-from .models import ExpansionCandidate, PlannerDecision
+from .models import ExpansionCandidate, IntentCandidate, IntentLabel, PlannerDecision
 from .providers import COMMON_QUERY_WORDS, ModelProviderBundle
 
 DOI_RE = re.compile(r"10\.\d{4,9}/[-._;()/:A-Za-z0-9]+", re.IGNORECASE)
@@ -57,6 +57,22 @@ QUERY_FACET_TOKEN_ALLOWLIST = {
     "tool",
     "tools",
 }
+LITERATURE_QUERY_TERMS = {
+    "article",
+    "citation",
+    "doi",
+    "evidence",
+    "journal",
+    "literature",
+    "meta-analysis",
+    "paper",
+    "peer-reviewed",
+    "review",
+    "scholarly",
+    "scientific",
+    "study",
+    "systematic review",
+}
 TITLE_STOPWORDS = {
     "a",
     "an",
@@ -74,17 +90,45 @@ TITLE_STOPWORDS = {
     "to",
     "with",
 }
+QUERYISH_TITLE_BLOCKERS = {
+    "compare",
+    "effects",
+    "evidence",
+    "history",
+    "include",
+    "listing",
+    "regulatory",
+    "review",
+    "status",
+    "studies",
+    "study",
+    "survey",
+    "systematic",
+    "what",
+}
+STRONG_REGULATORY_TITLE_BLOCKERS = {
+    "critical habitat",
+    "ecos",
+    "esa",
+    "federal register",
+    "final rule",
+    "listing status",
+    "regulatory history",
+    "rulemaking",
+}
 REGULATORY_QUERY_TERMS = {
     "biological opinion",
     "cfr",
     "code of federal regulations",
     "critical habitat",
     "ecos",
-    "endangered",
+    "esa",
+    "final rule",
     "federal register",
     "five-year review",
     "five year review",
     "incidental take",
+    "listing status",
     "listing history",
     "proposed rule",
     "recovery plan",
@@ -93,7 +137,6 @@ REGULATORY_QUERY_TERMS = {
     "rulemaking",
     "section 7",
     "species dossier",
-    "threatened",
 }
 
 VARIANT_DEDUPE_STOPWORDS = (
@@ -169,15 +212,26 @@ def looks_like_exact_title(query: str) -> bool:
     normalized = normalize_query(query)
     if not normalized or normalized.endswith("?"):
         return False
+    lowered = normalized.lower()
+    if any(marker in lowered for marker in STRONG_REGULATORY_TITLE_BLOCKERS):
+        return False
+    if re.search(r"\b\d+\s*(?:cfr|f\.?\s*r\.?)\b", lowered):
+        return False
+    if any(phrase in lowered for phrase in ("what does", "what is", "what are", "include representative")):
+        return False
     stripped = normalized.strip("\"'")
     words = re.findall(r"[A-Za-z][A-Za-z0-9'/-]*", stripped)
-    if not 2 <= len(words) <= 14:
+    if not 2 <= len(words) <= 24:
         return False
     significant_words = [word for word in words if len(word) > 2 and word.lower() not in TITLE_STOPWORDS]
     if len(significant_words) < 2:
         return False
+    if sum(word.lower() in QUERYISH_TITLE_BLOCKERS for word in significant_words) >= 3:
+        return False
     title_like_words = [word for word in significant_words if word[:1].isupper() or word.isupper() or "-" in word]
-    return len(title_like_words) >= max(2, int(len(significant_words) * 0.6))
+    if len(title_like_words) >= max(2, int(len(significant_words) * 0.45)):
+        return True
+    return bool(re.search(r"\([A-Z][A-Za-z]+(?:\s+[a-z][A-Za-z-]+)+\)", stripped)) and len(significant_words) >= 6
 
 
 def detect_regulatory_intent(query: str, focus: str | None = None) -> bool:
@@ -188,6 +242,21 @@ def detect_regulatory_intent(query: str, focus: str | None = None) -> bool:
         return False
     if any(term in normalized for term in REGULATORY_QUERY_TERMS):
         return True
+    if re.search(r"\b(?:endangered|threatened)\b", normalized) and any(
+        marker in normalized
+        for marker in {
+            "cfr",
+            "critical habitat",
+            "esa",
+            "federal register",
+            "final rule",
+            "listing",
+            "recovery plan",
+            "rulemaking",
+            "species status",
+        }
+    ):
+        return True
     if re.search(r"\b\d+\s*(?:cfr|f\.?\s*r\.?)\b", normalized):
         return True
     if "species" in normalized and any(
@@ -195,6 +264,107 @@ def detect_regulatory_intent(query: str, focus: str | None = None) -> bool:
     ):
         return True
     return False
+
+
+def detect_literature_intent(query: str, focus: str | None = None) -> bool:
+    """Return True when the ask explicitly signals literature or scholarly retrieval."""
+
+    normalized = normalize_query(" ".join(part for part in [query, focus or ""] if part)).lower()
+    if not normalized:
+        return False
+    if any(term in normalized for term in LITERATURE_QUERY_TERMS):
+        return True
+    return bool(re.search(r"\b(?:doi|peer-reviewed|systematic review|meta-analysis|scientific reports?)\b", normalized))
+
+
+def _source_for_intent_candidate(
+    intent_source: Literal["explicit", "planner", "heuristic_override", "hybrid_agreement", "fallback_recovery"],
+) -> Literal["explicit", "planner", "heuristic", "hybrid", "fallback"]:
+    mapping: dict[
+        Literal["explicit", "planner", "heuristic_override", "hybrid_agreement", "fallback_recovery"],
+        Literal["explicit", "planner", "heuristic", "hybrid", "fallback"],
+    ] = {
+        "explicit": "explicit",
+        "planner": "planner",
+        "heuristic_override": "heuristic",
+        "hybrid_agreement": "hybrid",
+        "fallback_recovery": "fallback",
+    }
+    return mapping[intent_source]
+
+
+def _confidence_rank(confidence: Literal["high", "medium", "low"]) -> int:
+    return {"high": 3, "medium": 2, "low": 1}[confidence]
+
+
+def _upsert_intent_candidate(
+    *,
+    candidates: list[IntentCandidate],
+    intent: IntentLabel,
+    confidence: Literal["high", "medium", "low"],
+    source: Literal["explicit", "planner", "heuristic", "hybrid", "fallback"],
+    rationale: str,
+) -> None:
+    for index, existing in enumerate(candidates):
+        if existing.intent != intent:
+            continue
+        merged_confidence = (
+            confidence if _confidence_rank(confidence) >= _confidence_rank(existing.confidence) else existing.confidence
+        )
+        merged_source = existing.source
+        if _confidence_rank(confidence) >= _confidence_rank(existing.confidence):
+            merged_source = source
+        merged_rationale = existing.rationale
+        if rationale and rationale not in merged_rationale:
+            merged_rationale = f"{merged_rationale} {rationale}".strip() if merged_rationale else rationale
+        candidates[index] = existing.model_copy(
+            update={
+                "confidence": merged_confidence,
+                "source": merged_source,
+                "rationale": merged_rationale,
+            }
+        )
+        return
+    candidates.append(
+        IntentCandidate(
+            intent=intent,
+            confidence=confidence,
+            source=source,
+            rationale=rationale,
+        )
+    )
+
+
+def _sort_intent_candidates(
+    candidates: list[IntentCandidate],
+    *,
+    preferred_intent: IntentLabel,
+) -> list[IntentCandidate]:
+    return sorted(
+        candidates,
+        key=lambda candidate: (
+            candidate.intent != preferred_intent,
+            -_confidence_rank(candidate.confidence),
+            candidate.intent,
+        ),
+    )
+
+
+def _strong_known_item_signal(normalized_query: str) -> bool:
+    return bool(
+        DOI_RE.search(normalized_query) or ARXIV_RE.search(normalized_query) or looks_like_url(normalized_query)
+    )
+
+
+def _strong_regulatory_signal(normalized_query: str, focus: str | None = None) -> bool:
+    combined = normalize_query(" ".join(part for part in [normalized_query, focus or ""] if part)).lower()
+    if re.search(r"\b\d+\s*(?:f\.?\s*r\.?)\s*\d+\b", combined):
+        return True
+    if re.search(r"\bfederal register\b", combined) and re.search(r"\b\d+\b", combined):
+        return True
+    if re.search(r"\b\d+\s*(?:cfr|f\.?\s*r\.?)\b", combined):
+        return True
+    return bool(re.search(r"\b\d{4}-\d{4,6}\b", combined))
 
 
 async def classify_query(
@@ -219,24 +389,147 @@ async def classify_query(
         request_outcomes=request_outcomes,
         request_id=request_id,
     )
+    planner.intent_source = "planner"
+    planner.intent_confidence = "medium"
+    intent_candidates = list(planner.intent_candidates)
+    _upsert_intent_candidate(
+        candidates=intent_candidates,
+        intent=planner.intent,
+        confidence=planner.intent_confidence,
+        source="planner",
+        rationale="Model planner selected this intent as the best initial route.",
+    )
     if mode != "auto":
         planner.intent = cast(
             Literal["discovery", "review", "known_item", "author", "citation", "regulatory"],
             mode,
         )
+        planner.intent_source = "explicit"
+        planner.intent_confidence = "high"
+        planner.intent_rationale = "Intent was set explicitly by the caller."
         if mode == "review":
             planner.follow_up_mode = "claim_check"
+        _upsert_intent_candidate(
+            candidates=intent_candidates,
+            intent=cast(IntentLabel, planner.intent),
+            confidence="high",
+            source="explicit",
+            rationale="Explicit mode parameter from the caller.",
+        )
     else:
-        if detect_regulatory_intent(normalized, focus):
-            planner.intent = "regulatory"
-        elif (
-            DOI_RE.search(normalized)
-            or ARXIV_RE.search(normalized)
-            or looks_like_url(normalized)
-            or looks_like_exact_title(query)
-            or looks_like_citation_query(normalized)
-        ):
-            planner.intent = "known_item"
+        citation_like_signal = looks_like_citation_query(normalized)
+        title_like_signal = looks_like_exact_title(query)
+        literature_signal = detect_literature_intent(normalized, focus)
+        strong_known_item_signal = _strong_known_item_signal(normalized)
+        strong_regulatory_signal = _strong_regulatory_signal(normalized, focus)
+        regulatory_signal = detect_regulatory_intent(normalized, focus)
+        if strong_known_item_signal:
+            _upsert_intent_candidate(
+                candidates=intent_candidates,
+                intent="known_item",
+                confidence="high",
+                source="heuristic",
+                rationale="Strong known-item signal (DOI, arXiv, or URL) was detected.",
+            )
+        elif citation_like_signal:
+            _upsert_intent_candidate(
+                candidates=intent_candidates,
+                intent="known_item",
+                confidence="medium",
+                source="heuristic",
+                rationale="Citation-like wording suggests a known-item anchor.",
+            )
+        elif title_like_signal:
+            _upsert_intent_candidate(
+                candidates=intent_candidates,
+                intent="known_item",
+                confidence="low",
+                source="heuristic",
+                rationale="Title-like phrasing suggests a possible known-item lookup.",
+            )
+
+        if strong_regulatory_signal:
+            _upsert_intent_candidate(
+                candidates=intent_candidates,
+                intent="regulatory",
+                confidence="high",
+                source="heuristic",
+                rationale="Explicit regulatory citation or rulemaking marker was detected.",
+            )
+        elif regulatory_signal:
+            _upsert_intent_candidate(
+                candidates=intent_candidates,
+                intent="regulatory",
+                confidence="low",
+                source="heuristic",
+                rationale="Regulatory phrasing is present but not strongly anchored.",
+            )
+        if literature_signal:
+            _upsert_intent_candidate(
+                candidates=intent_candidates,
+                intent="review",
+                confidence="low",
+                source="heuristic",
+                rationale="Literature/review language suggests synthesis intent.",
+            )
+
+        heuristic_override: IntentLabel | None = None
+        heuristic_override_confidence: Literal["high", "medium", "low"] = "medium"
+        heuristic_rationale = ""
+        known_item_override = strong_known_item_signal or (
+            (citation_like_signal or title_like_signal) and not strong_regulatory_signal
+        )
+        if known_item_override:
+            heuristic_override = "known_item"
+            heuristic_override_confidence = "high" if strong_known_item_signal else "medium"
+            heuristic_rationale = (
+                "Strong known-item signal overrode planner routing."
+                if strong_known_item_signal
+                else "Known-item guardrails (citation/title pattern) overrode planner routing."
+            )
+        elif regulatory_signal:
+            heuristic_override = "regulatory"
+            heuristic_override_confidence = "high" if strong_regulatory_signal else "medium"
+            heuristic_rationale = (
+                "Strong regulatory signal overrode planner routing."
+                if strong_regulatory_signal
+                else "Regulatory guardrails overrode planner routing."
+            )
+
+        if heuristic_override is not None:
+            if planner.intent == heuristic_override:
+                planner.intent_source = "hybrid_agreement"
+                planner.intent_confidence = "high"
+                planner.intent_rationale = "Planner intent matched strong deterministic guardrail signals."
+            else:
+                planner.intent = heuristic_override
+                planner.intent_source = "heuristic_override"
+                planner.intent_confidence = heuristic_override_confidence
+                planner.intent_rationale = heuristic_rationale
+        elif planner.intent_rationale.strip() == "":
+            planner.intent_rationale = "Planner intent selected without a strong deterministic override."
+
+    _upsert_intent_candidate(
+        candidates=intent_candidates,
+        intent=cast(IntentLabel, planner.intent),
+        confidence=planner.intent_confidence,
+        source=_source_for_intent_candidate(planner.intent_source),
+        rationale=planner.intent_rationale or "Final routed intent after planner and guardrail reconciliation.",
+    )
+    sorted_candidates = _sort_intent_candidates(intent_candidates, preferred_intent=cast(IntentLabel, planner.intent))
+    planner.intent_candidates = sorted_candidates[:4]
+    planner.secondary_intents = [
+        candidate.intent for candidate in planner.intent_candidates if candidate.intent != planner.intent
+    ][:3]
+    primary_candidate = next(
+        (candidate for candidate in planner.intent_candidates if candidate.intent == planner.intent),
+        None,
+    )
+    planner.routing_confidence = (
+        primary_candidate.confidence if primary_candidate is not None else planner.intent_confidence
+    )
+    if not planner.intent_rationale:
+        planner.intent_rationale = "Intent routed from planner defaults."
     merged_concepts = list(planner.candidate_concepts)
     merged_concepts.extend(query_facets(normalized))
     if focus:

--- a/paper_chaser_mcp/agentic/provider_langchain.py
+++ b/paper_chaser_mcp/agentic/provider_langchain.py
@@ -64,6 +64,7 @@ class LangChainChatProviderBundle(DeterministicProviderBundle):
         structured_output_method: str | None = None,
     ) -> None:
         super().__init__(config)
+        self._configured_provider = config.provider
         self._provider_name = provider_name
         self._api_key = api_key
         self._provider_registry = provider_registry

--- a/paper_chaser_mcp/agentic/provider_openai.py
+++ b/paper_chaser_mcp/agentic/provider_openai.py
@@ -60,6 +60,7 @@ class OpenAIProviderBundle(DeterministicProviderBundle):
         provider_registry: ProviderDiagnosticsRegistry | None = None,
     ) -> None:
         super().__init__(config)
+        self._configured_provider = config.provider
         self._provider_name = "openai"
         self.planner_model_name = config.planner_model
         self.synthesis_model_name = config.synthesis_model

--- a/paper_chaser_mcp/agentic/workspace.py
+++ b/paper_chaser_mcp/agentic/workspace.py
@@ -251,6 +251,32 @@ class WorkspaceRegistry:
             raise ExpiredSearchSessionError(f"searchSessionId {search_session_id!r} has expired.")
         return record
 
+    def latest(self, *, source_tool: str | None = None) -> SearchSessionRecord | None:
+        """Return the newest active record, optionally filtered by *source_tool*."""
+        self._cleanup()
+        candidates = [
+            record for record in self._records.values() if source_tool is None or record.source_tool == source_tool
+        ]
+        if not candidates:
+            return None
+        return max(candidates, key=lambda record: record.created_at)
+
+    def attach_source_aliases(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Return a payload copy with stable per-session source aliases attached."""
+        return self._attach_source_aliases(payload)
+
+    def active_records(
+        self,
+        *,
+        source_tools: set[str] | None = None,
+    ) -> list[SearchSessionRecord]:
+        """Return active records ordered from newest to oldest."""
+        self._cleanup()
+        records = list(self._records.values())
+        if source_tools is not None:
+            records = [record for record in records if record.source_tool in source_tools]
+        return sorted(records, key=lambda record: record.created_at, reverse=True)
+
     def search_papers(
         self,
         search_session_id: str,
@@ -408,17 +434,21 @@ class WorkspaceRegistry:
         metadata: dict[str, Any] | None,
         search_session_id: str | None,
     ) -> SearchSessionRecord:
-        papers = self._extract_papers(payload)
-        authors = self._extract_authors(payload)
+        normalized_payload = self._attach_source_aliases(payload)
+        papers = self._extract_papers(normalized_payload)
+        authors = self._extract_authors(normalized_payload)
         created_at = _now()
+        record_metadata = dict(metadata or {})
+        if alias_map := normalized_payload.get("sessionSourceAliases"):
+            record_metadata["sessionSourceAliases"] = alias_map
         record = SearchSessionRecord(
             search_session_id=search_session_id or self._new_search_session_id(),
             source_tool=source_tool,
             created_at=created_at,
             expires_at=created_at + self._ttl_seconds,
-            payload=payload,
+            payload=normalized_payload,
             query=query,
-            metadata=dict(metadata or {}),
+            metadata=record_metadata,
             papers=papers,
             authors=authors,
             indexed_papers=[
@@ -434,6 +464,38 @@ class WorkspaceRegistry:
         if self._index_backend == "faiss" and record.indexed_papers:
             record.vector_store_status = "pending"
         return record
+
+    @staticmethod
+    def _attach_source_aliases(payload: dict[str, Any]) -> dict[str, Any]:
+        normalized_payload = dict(payload)
+        alias_map: dict[str, str] = {}
+        alias_index = 1
+        for key in ("sources", "structuredSources", "candidateLeads"):
+            entries = normalized_payload.get(key)
+            if not isinstance(entries, list):
+                continue
+            updated_entries: list[Any] = []
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    updated_entries.append(entry)
+                    continue
+                source_id = str(entry.get("sourceId") or "").strip()
+                if not source_id:
+                    updated_entries.append(entry)
+                    continue
+                alias = alias_map.get(source_id)
+                if alias is None:
+                    alias = f"src_{alias_index}"
+                    alias_map[source_id] = alias
+                    alias_index += 1
+                updated_entry = dict(entry)
+                if not updated_entry.get("sourceAlias"):
+                    updated_entry["sourceAlias"] = alias
+                updated_entries.append(updated_entry)
+            normalized_payload[key] = updated_entries
+        if alias_map:
+            normalized_payload["sessionSourceAliases"] = alias_map
+        return normalized_payload
 
     def _store_record(self, record: SearchSessionRecord) -> None:
         existing = self._records.get(record.search_session_id)

--- a/paper_chaser_mcp/citation_repair.py
+++ b/paper_chaser_mcp/citation_repair.py
@@ -101,6 +101,54 @@ GENERIC_TITLE_WORDS = {
 logger = logging.getLogger("paper-chaser-mcp.citation-repair")
 
 
+def _normalize_identifier_for_semantic_scholar(identifier: str, identifier_type: str | None) -> str:
+    normalized = normalize_citation_text(identifier)
+    if not normalized:
+        return normalized
+    lowered = normalized.lower()
+    if identifier_type == "doi" or DOI_RE.fullmatch(normalized):
+        if lowered.startswith("doi:"):
+            return f"DOI:{normalized[4:].strip()}"
+        doi_match = DOI_RE.search(normalized)
+        if doi_match:
+            return f"DOI:{doi_match.group(0)}"
+    if identifier_type == "arxiv" or ARXIV_RE.fullmatch(normalized):
+        if lowered.startswith("arxiv:"):
+            return f"ARXIV:{normalized[6:].strip()}"
+        return f"ARXIV:{normalized}"
+    if identifier_type == "url" and looks_like_url(normalized):
+        parsed = urlparse(normalized)
+        if parsed.netloc.lower().endswith("semanticscholar.org"):
+            path_parts = [part for part in parsed.path.split("/") if part]
+            if path_parts:
+                candidate = path_parts[-1]
+                if re.fullmatch(r"[A-Fa-f0-9]{40}", candidate):
+                    return candidate
+        return f"URL:{normalized}"
+    return normalized
+
+
+def _normalize_identifier_for_openalex(identifier: str, identifier_type: str | None) -> str | None:
+    normalized = normalize_citation_text(identifier)
+    if not normalized:
+        return None
+    lowered = normalized.lower()
+    if identifier_type == "doi" or DOI_RE.fullmatch(normalized):
+        if lowered.startswith("doi:"):
+            normalized = normalized[4:].strip()
+        elif lowered.startswith("https://doi.org/"):
+            normalized = normalized[16:]
+        elif lowered.startswith("http://doi.org/"):
+            normalized = normalized[15:]
+        doi_match = DOI_RE.search(normalized)
+        return doi_match.group(0) if doi_match else None
+    if lowered.startswith("https://openalex.org/w") or lowered.startswith("http://openalex.org/w"):
+        return normalized.rstrip("/").rsplit("/", 1)[-1]
+    if re.fullmatch(r"W\d+", normalized, re.IGNORECASE):
+        return normalized
+    return None
+
+
 @dataclass(slots=True)
 class ParsedCitation:
     """Deterministic features extracted from a citation-like query."""
@@ -705,21 +753,25 @@ async def _resolve_identifier_candidate(
 ) -> RankedCitationCandidate | None:
     if not parsed.identifier:
         return None
+    semantic_identifier = _normalize_identifier_for_semantic_scholar(parsed.identifier, parsed.identifier_type)
+    openalex_identifier = _normalize_identifier_for_openalex(parsed.identifier, parsed.identifier_type)
     last_error: Exception | None = None
     for strategy, resolver in (
         (
             "identifier",
             lambda: client.get_paper_details(
-                paper_id=parsed.identifier,
+                paper_id=semantic_identifier,
                 fields=None,
             ),
         ),
         (
             "identifier_openalex",
-            lambda: openalex_client.get_paper_details(paper_id=parsed.identifier),
+            lambda: openalex_client.get_paper_details(paper_id=openalex_identifier),
         ),
     ):
         if strategy == "identifier_openalex" and not enable_openalex:
+            continue
+        if strategy == "identifier_openalex" and not openalex_identifier:
             continue
         try:
             paper = dump_jsonable(await resolver())
@@ -1019,7 +1071,7 @@ def _rank_candidate(
         except (TypeError, ValueError):
             year_delta = None
     venue_overlap = _venue_overlap(parsed, paper)
-    identifier_hit = _identifier_hit(parsed, paper)
+    identifier_hit = resolution_strategy.startswith("identifier") or _identifier_hit(parsed, paper)
     snippet_alignment = _snippet_alignment(parsed, paper, snippet_text=snippet_text)
     source_confidence = _source_confidence(resolution_strategy)
     upstream_confidence = str(paper.get("matchConfidence") or "").lower()

--- a/paper_chaser_mcp/clients/govinfo/client.py
+++ b/paper_chaser_mcp/clients/govinfo/client.py
@@ -216,6 +216,42 @@ class GovInfoClient:
             payload["historical"] = True
         return await self._request_json("POST", "/search", json_payload=payload)
 
+    async def search_federal_register_documents(self, *, query: str, limit: int = 10) -> dict[str, Any]:
+        if not self.api_key:
+            raise ValueError("search_federal_register_documents requires GOVINFO_API_KEY.")
+
+        normalized_query = " ".join(query.strip().split())
+        if not normalized_query:
+            return {"total": 0, "data": []}
+
+        search = await self._govinfo_search(f"collection:(FR) and {normalized_query}", historical=True)
+        results = search.get("results") or []
+        if not isinstance(results, list):
+            return {"total": 0, "data": []}
+
+        data: list[dict[str, Any]] = []
+        for result in results[:limit]:
+            if not isinstance(result, dict):
+                continue
+            granule_id = str(result.get("granuleId") or "").strip()
+            package_id = str(result.get("packageId") or "").strip()
+            citation = str(result.get("citation") or result.get("frcitation") or "").strip() or None
+            data.append(
+                {
+                    "title": str(result.get("title") or "").strip() or None,
+                    "documentNumber": granule_id or None,
+                    "citation": citation,
+                    "publicationDate": str(result.get("dateIssued") or "").strip() or None,
+                    "sourceUrl": str(result.get("packageLink") or result.get("granuleLink") or "").strip() or None,
+                    "govInfoPackageId": package_id or None,
+                    "govInfoGranuleId": granule_id or None,
+                    "verificationStatus": "verified_metadata",
+                    "note": "GovInfo Federal Register primary-source recovery hit.",
+                }
+            )
+
+        return {"total": len(data), "data": data}
+
     async def _resolve_fr_from_citation(self, citation: str) -> tuple[str | None, str | None, dict[str, Any] | None]:
         search = await self._govinfo_search(f'collection:(FR) and frcitation:"{citation}"')
         results = search.get("results") or []

--- a/paper_chaser_mcp/clients/semantic_scholar/client.py
+++ b/paper_chaser_mcp/clients/semantic_scholar/client.py
@@ -5,6 +5,7 @@ import re
 import time
 from difflib import SequenceMatcher
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 from ...citation_repair import build_match_metadata
 from ...constants import (
@@ -59,6 +60,8 @@ _ARXIV_URL_PATTERN = re.compile(
     r"https?://(?:www\.)?arxiv\.org/(?:abs|pdf)/([^\s/?#]+)",
     re.IGNORECASE,
 )
+_DOI_URL_PATTERN = re.compile(r"https?://(?:dx\.)?doi\.org/(10\.\d{4,9}/[^\s?#]+)", re.IGNORECASE)
+_BARE_DOI_PATTERN = re.compile(r"^10\.\d{4,9}/[-._;()/:A-Za-z0-9]+$", re.IGNORECASE)
 
 
 class SemanticScholarClient:
@@ -241,7 +244,10 @@ class SemanticScholarClient:
         2. Bare arXiv IDs (new-style ``YYMM.NNNNN`` or old-style
            ``category/NNNNNNN``) → ``ARXIV:<id>``
         3. ``https://arxiv.org/abs/<id>`` (or ``/pdf/``) → ``ARXIV:<id>``
-        4. Everything else is returned unchanged.
+        4. Bare DOIs and DOI URLs are normalized to ``DOI:<id>``.
+        5. Semantic Scholar paper URLs are reduced to their trailing paper id.
+        6. Other HTTP(S) URLs are normalized to ``URL:<url>``.
+        7. Everything else is returned unchanged.
         """
         stripped = paper_id.strip()
         # 1. Normalize case of arXiv: prefix
@@ -254,6 +260,25 @@ class SemanticScholarClient:
         url_match = _ARXIV_URL_PATTERN.match(stripped)
         if url_match:
             return "ARXIV:" + url_match.group(1)
+        # 4. Normalize DOI variants.
+        if re.match(r"^doi:", stripped, re.IGNORECASE):
+            return "DOI:" + stripped[len("doi:") :]
+        doi_url_match = _DOI_URL_PATTERN.match(stripped)
+        if doi_url_match:
+            return "DOI:" + doi_url_match.group(1)
+        if _BARE_DOI_PATTERN.match(stripped):
+            return "DOI:" + stripped
+        # 5. Semantic Scholar paper URLs end with a portable paper id.
+        parsed = urlparse(stripped)
+        if parsed.scheme in {"http", "https"} and parsed.netloc.lower().endswith("semanticscholar.org"):
+            path_parts = [part for part in parsed.path.split("/") if part]
+            if path_parts:
+                candidate = path_parts[-1]
+                if re.fullmatch(r"[A-Fa-f0-9]{40}", candidate):
+                    return candidate
+        # 6. Generic URLs should use the Semantic Scholar URL: prefix.
+        if parsed.scheme in {"http", "https"} and parsed.netloc:
+            return f"URL:{stripped}"
         return stripped
 
     @staticmethod

--- a/paper_chaser_mcp/dispatch.py
+++ b/paper_chaser_mcp/dispatch.py
@@ -1,12 +1,13 @@
 """Dispatch helpers for MCP tool routing."""
 
+import logging
 import re
 import time
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as package_version
 from typing import Any, Callable, cast
 
-from .agentic.planner import detect_regulatory_intent, query_facets, query_terms
+from .agentic.planner import detect_regulatory_intent, looks_like_exact_title, query_facets, query_terms
 from .citation_repair import looks_like_citation_query, looks_like_paper_identifier, parse_citation, resolve_citation
 from .clients.scholarapi import (
     ScholarApiError,
@@ -75,6 +76,8 @@ SCHOLARAPI_LIST_RETRIEVAL_NOTE = (
     "For topical search use search_papers_scholarapi, and pass pagination.nextCursor back exactly as "
     "returned to continue the same stream."
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _provider_error_text(exc: Exception) -> str:
@@ -850,6 +853,7 @@ def _guided_source_id(candidate: dict[str, Any], *, fallback_prefix: str, index:
 def _guided_source_record_from_structured_source(source: dict[str, Any], *, index: int) -> dict[str, Any]:
     return {
         "sourceId": _guided_source_id(source, fallback_prefix="source", index=index),
+        "sourceAlias": f"source-{index}",
         "title": source.get("title"),
         "provider": source.get("provider"),
         "sourceType": source.get("sourceType") or "unknown",
@@ -881,6 +885,7 @@ def _guided_source_record_from_paper(query: str, paper: dict[str, Any], *, index
     confidence = paper.get("confidence") or ("high" if topical_relevance == "on_topic" else "medium")
     return {
         "sourceId": _guided_source_id(paper, fallback_prefix="paper", index=index),
+        "sourceAlias": f"source-{index}",
         "title": paper.get("title"),
         "provider": paper.get("source"),
         "sourceType": source_type,
@@ -938,6 +943,622 @@ def _guided_unverified_leads_from_sources(sources: list[dict[str, Any]]) -> list
             seen.add(source_id)
         leads.append(source)
     return leads[:6]
+
+
+_GUIDED_LITERATURE_TERMS = {
+    "article",
+    "articles",
+    "citation",
+    "citations",
+    "doi",
+    "evidence",
+    "journal",
+    "journals",
+    "literature",
+    "meta-analysis",
+    "paper",
+    "papers",
+    "peer-reviewed",
+    "review",
+    "reviews",
+    "scholarly",
+    "science",
+    "scientific",
+    "study",
+    "studies",
+    "systematic review",
+}
+
+
+_GUIDED_QUERY_PREFIX_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"^\s*(?:please\s+|kindly\s+)?(?:help\s+me\s+)?(?:find|search(?:\s+for)?|look\s+up|research|summarize|show)\s+"
+        r"(?:papers?|literature|studies|evidence|sources?|information)\s+(?:about|on|for)\s+",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^\s*(?:please\s+|kindly\s+)?(?:help\s+me\s+)?(?:find|search(?:\s+for)?|look\s+up|research|summarize|show)\s+",
+        re.IGNORECASE,
+    ),
+)
+
+_GUIDED_CFR_SECTION_RE = re.compile(
+    r"\b(?P<title>\d{1,2})\s*c\.?\s*f\.?\s*r\.?\s*(?P<part>\d{1,4})\s*(?:[.\-:/]\s*|\s+)(?P<section>\d{1,4})\b",
+    re.IGNORECASE,
+)
+_GUIDED_CFR_PART_RE = re.compile(
+    r"\b(?P<title>\d{1,2})\s*c\.?\s*f\.?\s*r\.?\s*part\s*(?P<part>\d{1,4})\b",
+    re.IGNORECASE,
+)
+_GUIDED_FR_CITATION_RE = re.compile(
+    r"\b(?P<volume>\d+)\s*f\.?\s*r\.?\s*(?P<page>\d+)\b",
+    re.IGNORECASE,
+)
+_GUIDED_YEAR_RANGE_RE = re.compile(r"\b(?P<start>(?:19|20)\d{2})\s*[-:/]\s*(?P<end>(?:19|20)\d{2})\b")
+_GUIDED_YEAR_RE = re.compile(r"\b(?:19|20)\d{2}\b")
+
+
+def _guided_normalize_whitespace(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def _guided_strip_research_prefix(query: str) -> str:
+    stripped = query
+    for pattern in _GUIDED_QUERY_PREFIX_PATTERNS:
+        candidate = pattern.sub("", stripped, count=1).strip()
+        if candidate and candidate != stripped:
+            return candidate
+    return stripped
+
+
+def _guided_normalize_citation_surface(text: str) -> str:
+    normalized = text
+    normalized = _GUIDED_CFR_SECTION_RE.sub(r"\g<title> CFR \g<part>.\g<section>", normalized)
+    normalized = _GUIDED_CFR_PART_RE.sub(r"\g<title> CFR Part \g<part>", normalized)
+    normalized = _GUIDED_FR_CITATION_RE.sub(r"\g<volume> FR \g<page>", normalized)
+    return normalized
+
+
+def _guided_normalize_year_hint(value: Any) -> str | None:
+    text = _guided_normalize_whitespace(value)
+    if not text:
+        return None
+    range_match = _GUIDED_YEAR_RANGE_RE.search(text)
+    if range_match:
+        start = range_match.group("start")
+        end = range_match.group("end")
+        return f"{start}:{end}" if start <= end else f"{end}:{start}"
+    years = _GUIDED_YEAR_RE.findall(text)
+    if len(years) >= 2:
+        start, end = years[0], years[1]
+        return f"{start}:{end}" if start <= end else f"{end}:{start}"
+    if years:
+        return years[0]
+    return text
+
+
+def _guided_note_repair(
+    repairs: list[dict[str, str]],
+    *,
+    field: str,
+    original: Any,
+    normalized: Any,
+    reason: str,
+) -> None:
+    if original == normalized:
+        return
+    repairs.append(
+        {
+            "field": field,
+            "from": str(original if original is not None else ""),
+            "to": str(normalized if normalized is not None else ""),
+            "reason": reason,
+        }
+    )
+
+
+def _guided_session_exists(
+    *,
+    workspace_registry: Any,
+    search_session_id: str | None,
+) -> bool:
+    if workspace_registry is None:
+        return False
+    normalized_id = _guided_normalize_whitespace(search_session_id)
+    if not normalized_id:
+        return False
+    try:
+        workspace_registry.get(normalized_id)
+    except Exception:
+        return False
+    return True
+
+
+def _guided_active_session_ids(workspace_registry: Any) -> list[str]:
+    if workspace_registry is None:
+        return []
+    records = getattr(workspace_registry, "_records", None)
+    if not isinstance(records, dict):
+        return []
+    active: list[tuple[float, str]] = []
+    now = time.time()
+    for session_id, record in records.items():
+        if not isinstance(session_id, str) or not session_id.strip():
+            continue
+        if record is None:
+            continue
+        is_expired = getattr(record, "is_expired", None)
+        expired = False
+        if callable(is_expired):
+            try:
+                expired = bool(is_expired(now))
+            except Exception as exc:
+                logger.debug("Failed to evaluate session expiration for %s: %s", session_id, exc)
+                expired = True
+        if expired:
+            continue
+        created_at = float(getattr(record, "created_at", 0.0) or 0.0)
+        active.append((created_at, session_id))
+    active.sort(key=lambda item: item[0], reverse=True)
+    return [session_id for _, session_id in active]
+
+
+_GUIDED_RECOVERABLE_SESSION_TOOLS = {"research", "search_papers_smart"}
+
+
+def _guided_candidate_records(
+    workspace_registry: Any,
+    *,
+    require_sources: bool = False,
+) -> list[Any]:
+    if workspace_registry is None:
+        return []
+    active_records = getattr(workspace_registry, "active_records", None)
+    records: list[Any] = []
+    if callable(active_records):
+        try:
+            records = list(active_records(source_tools=_GUIDED_RECOVERABLE_SESSION_TOOLS))
+        except Exception as exc:
+            logger.debug("Failed to read active workspace records: %s", exc)
+            records = []
+    if not records:
+        for session_id in _guided_active_session_ids(workspace_registry):
+            record = None
+            try:
+                record = workspace_registry.get(session_id)
+            except Exception as exc:
+                logger.debug("Failed to load workspace record %s: %s", session_id, exc)
+            if str(getattr(record, "source_tool", "") or "") not in _GUIDED_RECOVERABLE_SESSION_TOOLS:
+                continue
+            records.append(record)
+    if require_sources:
+        records = [record for record in records if _guided_record_source_candidates(record)]
+    return records
+
+
+def _guided_latest_compatible_session_id(
+    workspace_registry: Any,
+    *,
+    require_sources: bool = False,
+) -> str | None:
+    records = _guided_candidate_records(workspace_registry, require_sources=require_sources)
+    if not records:
+        return None
+    return str(getattr(records[0], "search_session_id", "") or "") or None
+
+
+def _guided_unique_compatible_session_id(
+    workspace_registry: Any,
+    *,
+    require_sources: bool = False,
+) -> str | None:
+    records = _guided_candidate_records(workspace_registry, require_sources=require_sources)
+    if len(records) != 1:
+        return None
+    return str(getattr(records[0], "search_session_id", "") or "") or None
+
+
+def _guided_resolve_session_id_for_source(
+    workspace_registry: Any,
+    source_id: str | None,
+) -> tuple[str | None, str | None]:
+    normalized_source_id = _guided_normalize_whitespace(source_id)
+    if not normalized_source_id:
+        return _guided_unique_compatible_session_id(workspace_registry, require_sources=True), None
+
+    matched_records: list[tuple[str | None, str | None]] = []
+    for record in _guided_candidate_records(workspace_registry, require_sources=True):
+        resolved, match_type = _find_record_source_with_resolution(
+            workspace_registry=workspace_registry,
+            search_session_id=str(getattr(record, "search_session_id", "") or ""),
+            source_id=normalized_source_id,
+        )
+        if resolved is not None:
+            matched_records.append((str(getattr(record, "search_session_id", "") or "") or None, match_type))
+    if len(matched_records) == 1:
+        return matched_records[0]
+    return _guided_unique_compatible_session_id(workspace_registry, require_sources=True), None
+
+
+def _guided_infer_single_session_id(workspace_registry: Any) -> str | None:
+    return _guided_unique_compatible_session_id(workspace_registry)
+
+
+def _guided_normalize_research_arguments(arguments: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    normalized_args = dict(arguments)
+    repairs: list[dict[str, str]] = []
+    warnings: list[str] = []
+
+    raw_query = _guided_normalize_whitespace(arguments.get("query"))
+    normalized_query = _guided_normalize_citation_surface(_guided_strip_research_prefix(raw_query))
+    if not normalized_query:
+        raw_focus = _guided_normalize_whitespace(arguments.get("focus"))
+        if raw_focus:
+            normalized_query = _guided_normalize_citation_surface(raw_focus)
+            warnings.append("query was empty; reused normalized focus as the research query.")
+    normalized_args["query"] = normalized_query or raw_query
+    _guided_note_repair(
+        repairs,
+        field="query",
+        original=arguments.get("query"),
+        normalized=normalized_args["query"],
+        reason="query_normalization",
+    )
+
+    normalized_focus = _guided_normalize_citation_surface(_guided_normalize_whitespace(arguments.get("focus")))
+    normalized_args["focus"] = normalized_focus or None
+    _guided_note_repair(
+        repairs,
+        field="focus",
+        original=arguments.get("focus"),
+        normalized=normalized_args["focus"],
+        reason="focus_normalization",
+    )
+
+    normalized_venue = _guided_normalize_whitespace(arguments.get("venue")) or None
+    normalized_args["venue"] = normalized_venue
+    _guided_note_repair(
+        repairs,
+        field="venue",
+        original=arguments.get("venue"),
+        normalized=normalized_venue,
+        reason="venue_normalization",
+    )
+
+    normalized_year = _guided_normalize_year_hint(arguments.get("year"))
+    normalized_args["year"] = normalized_year
+    _guided_note_repair(
+        repairs,
+        field="year",
+        original=arguments.get("year"),
+        normalized=normalized_year,
+        reason="year_normalization",
+    )
+
+    normalization = {
+        "normalizedQuery": normalized_args.get("query"),
+        "normalizedFocus": normalized_args.get("focus"),
+        "normalizedVenue": normalized_args.get("venue"),
+        "normalizedYear": normalized_args.get("year"),
+        "repairs": repairs,
+        "warnings": warnings,
+    }
+    return normalized_args, normalization
+
+
+def _guided_normalize_follow_up_arguments(
+    arguments: dict[str, Any],
+    *,
+    workspace_registry: Any,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    normalized_args = dict(arguments)
+    repairs: list[dict[str, str]] = []
+    warnings: list[str] = []
+
+    raw_search_session_id = next(
+        (
+            arguments.get(key)
+            for key in (
+                "searchSessionId",
+                "search_session_id",
+                "sessionId",
+                "session_id",
+                "session",
+            )
+            if arguments.get(key) is not None
+        ),
+        None,
+    )
+    normalized_search_session_id = _guided_normalize_whitespace(raw_search_session_id)
+    if normalized_search_session_id and not _guided_session_exists(
+        workspace_registry=workspace_registry,
+        search_session_id=normalized_search_session_id,
+    ):
+        inferred_id = _guided_infer_single_session_id(workspace_registry)
+        if inferred_id is not None:
+            warnings.append(
+                "searchSessionId "
+                f"'{normalized_search_session_id}' was unavailable; using active session '{inferred_id}'."
+            )
+            normalized_search_session_id = inferred_id
+    if not normalized_search_session_id:
+        inferred_id = _guided_infer_single_session_id(workspace_registry)
+        if inferred_id is not None:
+            normalized_search_session_id = inferred_id
+            warnings.append(f"searchSessionId was missing; inferred active session '{inferred_id}'.")
+        elif len(_guided_candidate_records(workspace_registry)) > 1:
+            warnings.append(
+                "searchSessionId was missing and multiple active sessions exist; provide an explicit searchSessionId."
+            )
+    normalized_args["searchSessionId"] = normalized_search_session_id
+    _guided_note_repair(
+        repairs,
+        field="searchSessionId",
+        original=raw_search_session_id,
+        normalized=normalized_search_session_id,
+        reason="session_id_normalization",
+    )
+
+    raw_question = next(
+        (arguments.get(key) for key in ("question", "prompt", "query") if arguments.get(key) is not None),
+        None,
+    )
+    normalized_question = _guided_normalize_whitespace(raw_question)
+    normalized_args["question"] = normalized_question
+    _guided_note_repair(
+        repairs,
+        field="question",
+        original=raw_question,
+        normalized=normalized_question,
+        reason="question_normalization",
+    )
+    if not normalized_question:
+        warnings.append("question was empty after normalization; follow-up quality may be limited.")
+
+    normalization = {
+        "normalizedSearchSessionId": normalized_args.get("searchSessionId"),
+        "normalizedQuestion": normalized_args.get("question"),
+        "repairs": repairs,
+        "warnings": warnings,
+    }
+    return normalized_args, normalization
+
+
+def _guided_normalize_inspect_arguments(
+    arguments: dict[str, Any],
+    *,
+    workspace_registry: Any,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    normalized_args = dict(arguments)
+    repairs: list[dict[str, str]] = []
+    warnings: list[str] = []
+
+    raw_search_session_id = next(
+        (
+            arguments.get(key)
+            for key in (
+                "searchSessionId",
+                "search_session_id",
+                "sessionId",
+                "session_id",
+                "session",
+            )
+            if arguments.get(key) is not None
+        ),
+        None,
+    )
+    normalized_search_session_id = _guided_normalize_whitespace(raw_search_session_id)
+    if normalized_search_session_id and not _guided_session_exists(
+        workspace_registry=workspace_registry,
+        search_session_id=normalized_search_session_id,
+    ):
+        inferred_id = _guided_infer_single_session_id(workspace_registry)
+        if inferred_id is not None:
+            warnings.append(
+                "searchSessionId "
+                f"'{normalized_search_session_id}' was unavailable; using active session '{inferred_id}'."
+            )
+            normalized_search_session_id = inferred_id
+    if not normalized_search_session_id:
+        inferred_id = _guided_infer_single_session_id(workspace_registry)
+        if inferred_id is not None:
+            normalized_search_session_id = inferred_id
+            warnings.append(f"searchSessionId was missing; inferred active session '{inferred_id}'.")
+        elif len(_guided_candidate_records(workspace_registry)) > 1:
+            warnings.append(
+                "searchSessionId was missing and multiple active sessions exist; provide an explicit searchSessionId."
+            )
+    normalized_args["searchSessionId"] = normalized_search_session_id
+    _guided_note_repair(
+        repairs,
+        field="searchSessionId",
+        original=raw_search_session_id,
+        normalized=normalized_search_session_id,
+        reason="session_id_normalization",
+    )
+
+    raw_source_id = next(
+        (
+            arguments.get(key)
+            for key in ("sourceId", "source_id", "source", "sourceRef", "id")
+            if arguments.get(key) is not None
+        ),
+        None,
+    )
+    normalized_source_id = _guided_normalize_whitespace(raw_source_id)
+    if not normalized_search_session_id:
+        inferred_session_id, _ = _guided_resolve_session_id_for_source(workspace_registry, normalized_source_id)
+        if inferred_session_id is not None:
+            normalized_search_session_id = inferred_session_id
+            normalized_args["searchSessionId"] = normalized_search_session_id
+            warnings.append(
+                f"searchSessionId was missing; inferred source-bearing session '{normalized_search_session_id}'."
+            )
+    if not normalized_source_id and normalized_search_session_id and workspace_registry is not None:
+        record = None
+        try:
+            record = workspace_registry.get(normalized_search_session_id)
+        except Exception as exc:
+            logger.debug(
+                "Failed to load workspace record %s while inferring sourceId: %s",
+                normalized_search_session_id,
+                exc,
+            )
+        if record is not None:
+            candidates = _guided_record_source_candidates(record)
+            if len(candidates) == 1:
+                normalized_source_id = _guided_normalize_whitespace(candidates[0].get("sourceId"))
+                warnings.append(f"sourceId was missing; inferred the only inspectable source '{normalized_source_id}'.")
+    normalized_args["sourceId"] = normalized_source_id
+    _guided_note_repair(
+        repairs,
+        field="sourceId",
+        original=raw_source_id,
+        normalized=normalized_source_id,
+        reason="source_id_normalization",
+    )
+    if not normalized_source_id:
+        warnings.append("sourceId was empty after normalization; source inspection may fail.")
+
+    normalization = {
+        "normalizedSearchSessionId": normalized_args.get("searchSessionId"),
+        "normalizedSourceId": normalized_args.get("sourceId"),
+        "repairs": repairs,
+        "warnings": warnings,
+    }
+    return normalized_args, normalization
+
+
+def _guided_normalization_payload(normalization: dict[str, Any]) -> dict[str, Any] | None:
+    repairs = [repair for repair in normalization.get("repairs") or [] if isinstance(repair, dict)]
+    warnings = [warning for warning in normalization.get("warnings") or [] if isinstance(warning, str) and warning]
+    if not repairs and not warnings:
+        return None
+    payload = dict(normalization)
+    payload["repairs"] = repairs
+    payload["warnings"] = warnings
+    return payload
+
+
+def _guided_is_known_item_query(query: str) -> bool:
+    return looks_like_paper_identifier(query) or looks_like_citation_query(query) or looks_like_exact_title(query)
+
+
+def _guided_mentions_literature(query: str, focus: str | None = None) -> bool:
+    normalized = " ".join(part for part in [query, focus or ""] if part).lower()
+    if not normalized:
+        return False
+    if any(term in normalized for term in _GUIDED_LITERATURE_TERMS):
+        return True
+    return bool(re.search(r"\b(?:doi|systematic review|meta-analysis|peer-reviewed|scientific reports?)\b", normalized))
+
+
+def _guided_is_mixed_intent_query(query: str, focus: str | None = None) -> bool:
+    return detect_regulatory_intent(query, focus) and _guided_mentions_literature(query, focus)
+
+
+def _guided_dedupe_source_records(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    deduped: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for source in sources:
+        key = (
+            str(source.get("sourceId") or "").strip(),
+            str(source.get("canonicalUrl") or "").strip(),
+            str(source.get("title") or "").strip().lower(),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(source)
+    return deduped
+
+
+def _guided_merge_coverage_summaries(*coverages: dict[str, Any] | None) -> dict[str, Any] | None:
+    usable = [coverage for coverage in coverages if isinstance(coverage, dict)]
+    if not usable:
+        return None
+
+    def _merge_list(field: str) -> list[Any]:
+        merged: list[Any] = []
+        seen_values: set[str] = set()
+        for coverage in usable:
+            for item in coverage.get(field) or []:
+                marker = repr(item)
+                if marker in seen_values:
+                    continue
+                seen_values.add(marker)
+                merged.append(item)
+        return merged
+
+    likely_completeness = "none"
+    for candidate in ("complete", "partial", "unknown", "incomplete", "none"):
+        if any(str(coverage.get("likelyCompleteness") or "") == candidate for coverage in usable):
+            likely_completeness = candidate
+            break
+
+    merged: dict[str, Any] = {
+        "providersAttempted": _merge_list("providersAttempted"),
+        "providersSucceeded": _merge_list("providersSucceeded"),
+        "providersFailed": _merge_list("providersFailed"),
+        "providersZeroResults": _merge_list("providersZeroResults"),
+        "likelyCompleteness": likely_completeness,
+        "searchMode": "guided_hybrid_research",
+        "retrievalNotes": _merge_list("retrievalNotes"),
+    }
+    primary_document_coverage = usable[0].get("primaryDocumentCoverage")
+    for coverage in usable:
+        if coverage.get("primaryDocumentCoverage"):
+            primary_document_coverage = coverage.get("primaryDocumentCoverage")
+            break
+    if primary_document_coverage is not None:
+        merged["primaryDocumentCoverage"] = primary_document_coverage
+    merged["summaryLine"] = (
+        f"{len(merged['providersAttempted'])} provider(s) searched across blended literature and regulatory passes, "
+        f"{len(merged['providersFailed'])} failed, {len(merged['providersZeroResults'])} returned zero results, "
+        f"likely completeness: {likely_completeness}."
+    )
+    return merged
+
+
+def _guided_merge_failure_summaries(*summaries: dict[str, Any] | None) -> dict[str, Any] | None:
+    usable = [summary for summary in summaries if isinstance(summary, dict)]
+    if not usable:
+        return None
+    if len(usable) == 1:
+        return dict(usable[0])
+    what_failed = (
+        "; ".join(
+            str(summary.get("whatFailed") or "").strip()
+            for summary in usable
+            if str(summary.get("whatFailed") or "").strip()
+        )
+        or None
+    )
+    what_still_worked_parts = [
+        str(summary.get("whatStillWorked") or "").strip()
+        for summary in usable
+        if str(summary.get("whatStillWorked") or "").strip()
+    ]
+    completeness_parts = [
+        str(summary.get("completenessImpact") or "").strip()
+        for summary in usable
+        if str(summary.get("completenessImpact") or "").strip()
+    ]
+    return {
+        "outcome": "fallback_success" if any(summary.get("fallbackAttempted") for summary in usable) else "no_failure",
+        "whatFailed": what_failed,
+        "whatStillWorked": " ".join(dict.fromkeys(what_still_worked_parts)) or None,
+        "fallbackAttempted": any(bool(summary.get("fallbackAttempted")) for summary in usable),
+        "fallbackMode": "guided_hybrid_research",
+        "primaryPathFailureReason": "; ".join(
+            str(summary.get("primaryPathFailureReason") or "").strip()
+            for summary in usable
+            if str(summary.get("primaryPathFailureReason") or "").strip()
+        )
+        or None,
+        "completenessImpact": " ".join(dict.fromkeys(completeness_parts)) or None,
+        "recommendedNextAction": "review_partial_results",
+    }
 
 
 def _guided_open_access_route(source: dict[str, Any]) -> str:
@@ -1095,10 +1716,16 @@ def _guided_result_meaning(
     evidence_gaps: list[str],
     coverage: dict[str, Any] | None,
     failure_summary: dict[str, Any],
+    source_count: int = 0,
 ) -> str:
     if verified_findings:
         return f"This result contains {len(verified_findings)} verified finding(s) grounded in the returned sources."
     if status == "partial":
+        if source_count <= 0:
+            return (
+                "This result is currently metadata-only and did not include inspectable sources. "
+                "Use follow_up_research or rerun research with a tighter anchor."
+            )
         return "This result found some relevant evidence, but the trust or coverage state is still incomplete."
     if status == "needs_disambiguation":
         return "This result needs a stronger anchor before the server can produce a grounded answer."
@@ -1115,6 +1742,7 @@ def _guided_research_status(
     intent: str,
     sources: list[dict[str, Any]],
     findings: list[dict[str, Any]],
+    unverified_leads_count: int,
     coverage_summary: dict[str, Any] | None,
     failure_summary: dict[str, Any] | None,
     clarification: dict[str, Any] | None,
@@ -1138,15 +1766,88 @@ def _guided_research_status(
                 return "partial" if failure_summary is not None else "succeeded"
             if primary_sources:
                 return "partial"
+            if unverified_leads_count > 0:
+                return "partial"
             return "abstained"
         if primary_sources:
             return "partial" if failure_summary is not None else "succeeded"
+        if unverified_leads_count > 0:
+            return "partial"
         return "needs_disambiguation" if sources else "abstained"
     if len(findings) >= 2:
         return "partial" if failure_summary is not None else "succeeded"
     if sources:
         return "partial"
+    if unverified_leads_count > 0:
+        return "partial"
     return "abstained"
+
+
+def _guided_machine_failure_payload(
+    *,
+    search_session_id: str | None,
+    error: Exception,
+    normalization: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    evidence_gaps = ["Smart runtime returned an invalid or unstructured result payload, so guided output was degraded."]
+    failure_summary = _guided_failure_summary(
+        failure_summary={
+            "outcome": "total_failure",
+            "whatFailed": "smart_runtime_structural_failure",
+            "whatStillWorked": "The guided wrapper recovered and returned a machine-readable failure state.",
+            "fallbackAttempted": False,
+            "fallbackMode": None,
+            "primaryPathFailureReason": str(type(error).__name__),
+            "completenessImpact": evidence_gaps[0],
+            "recommendedNextAction": "research",
+        },
+        status="partial",
+        sources=[],
+        evidence_gaps=evidence_gaps,
+    )
+    payload: dict[str, Any] = {
+        "intent": "discovery",
+        "status": "partial",
+        "searchSessionId": search_session_id,
+        "summary": "Smart retrieval failed structurally; the server returned a safe machine-readable failure state.",
+        "verifiedFindings": [],
+        "sources": [],
+        "unverifiedLeads": [],
+        "evidenceGaps": evidence_gaps,
+        "trustSummary": _guided_trust_summary([], evidence_gaps),
+        "coverage": None,
+        "failureSummary": failure_summary,
+        "resultMeaning": _guided_result_meaning(
+            status="partial",
+            verified_findings=[],
+            evidence_gaps=evidence_gaps,
+            coverage=None,
+            failure_summary=failure_summary,
+            source_count=0,
+        ),
+        "nextActions": _guided_next_actions(
+            search_session_id=search_session_id,
+            status="partial",
+            has_sources=False,
+        ),
+        "resultState": _guided_result_state(
+            status="partial",
+            sources=[],
+            evidence_gaps=evidence_gaps,
+            search_session_id=search_session_id,
+        ),
+        "machineFailure": {
+            "category": "smart_runtime_structural_failure",
+            "errorType": type(error).__name__,
+            "error": str(error),
+            "retryable": True,
+            "bestNextInternalAction": "research",
+        },
+    }
+    normalization_payload = _guided_normalization_payload(normalization or {})
+    if normalization_payload is not None:
+        payload["inputNormalization"] = normalization_payload
+    return payload
 
 
 def _guided_summary(intent: str, status: str, findings: list[dict[str, Any]], sources: list[dict[str, Any]]) -> str:
@@ -1167,12 +1868,14 @@ def _guided_next_actions(
     *,
     search_session_id: str | None,
     status: str,
+    has_sources: bool,
 ) -> list[str]:
     actions: list[str] = []
-    if search_session_id:
+    if search_session_id and has_sources:
         actions.append(
             f"Use inspect_source with searchSessionId='{search_session_id}' and one sourceId to inspect evidence."
         )
+    if search_session_id:
         actions.append(
             f"Use follow_up_research with searchSessionId='{search_session_id}' to ask one grounded follow-up question."
         )
@@ -1186,39 +1889,207 @@ def _guided_next_actions(
     return actions[:4]
 
 
+def _guided_missing_evidence_type(
+    *,
+    status: str,
+    evidence_gaps: list[str],
+    sources: list[dict[str, Any]],
+) -> str:
+    if status in {"succeeded", "answered"}:
+        return "none"
+    joined_gaps = " ".join(str(gap).lower() for gap in evidence_gaps)
+    if "off-topic" in joined_gaps:
+        return "off_topic_only"
+    if any(marker in joined_gaps for marker in ("clarif", "anchor", "disambiguation")):
+        return "anchor_missing"
+    if any(marker in joined_gaps for marker in ("provider", "timeout", "failed", "error")):
+        return "provider_gap"
+    if not sources:
+        return "no_sources"
+    return "coverage_gap"
+
+
+def _guided_best_next_internal_action(
+    *,
+    status: str,
+    has_sources: bool,
+    search_session_id: str | None,
+) -> str:
+    if has_sources and search_session_id:
+        return "inspect_source"
+    if search_session_id:
+        return "follow_up_research"
+    if status in {"abstained", "needs_disambiguation", "failed"}:
+        return "research"
+    return "research"
+
+
+def _guided_result_state(
+    *,
+    status: str,
+    sources: list[dict[str, Any]],
+    evidence_gaps: list[str],
+    search_session_id: str | None,
+) -> dict[str, Any]:
+    has_sources = bool(sources)
+    normalized_status = str(status or "").strip() or "unknown"
+    if normalized_status in {"succeeded", "answered"} and has_sources:
+        groundedness = "grounded"
+    elif normalized_status == "answered":
+        groundedness = "partial"
+    elif normalized_status in {"partial", "insufficient_evidence"}:
+        groundedness = "partial"
+    elif normalized_status in {"abstained", "needs_disambiguation", "failed"}:
+        groundedness = "insufficient_evidence"
+    else:
+        groundedness = "unknown"
+    return {
+        "status": normalized_status,
+        "groundedness": groundedness,
+        "hasInspectableSources": has_sources,
+        "canAnswerFollowUp": bool(search_session_id),
+        "bestNextInternalAction": _guided_best_next_internal_action(
+            status=normalized_status,
+            has_sources=has_sources,
+            search_session_id=search_session_id,
+        ),
+        "missingEvidenceType": _guided_missing_evidence_type(
+            status=normalized_status,
+            evidence_gaps=evidence_gaps,
+            sources=sources,
+        ),
+    }
+
+
+def _guided_record_source_candidates(record: Any) -> list[dict[str, Any]]:
+    payload = record.payload if isinstance(record.payload, dict) else {}
+    explicit_sources = [source for source in payload.get("sources") or [] if isinstance(source, dict)]
+    if explicit_sources:
+        return _guided_dedupe_source_records(explicit_sources)
+
+    structured_sources = [
+        _guided_source_record_from_structured_source(source, index=index)
+        for index, source in enumerate(payload.get("structuredSources") or [], start=1)
+        if isinstance(source, dict)
+    ]
+    if structured_sources:
+        return _guided_dedupe_source_records(structured_sources)
+
+    query = str(record.query or payload.get("query") or "")
+    paper_sources = [
+        _guided_source_record_from_paper(query, paper, index=index)
+        for index, paper in enumerate(getattr(record, "papers", []) or [], start=1)
+        if isinstance(paper, dict)
+    ]
+    return _guided_dedupe_source_records(paper_sources)
+
+
+def _find_record_source_with_resolution(
+    *,
+    workspace_registry: Any,
+    search_session_id: str | None,
+    source_id: str,
+) -> tuple[dict[str, Any] | None, str]:
+    if workspace_registry is None:
+        return None, "workspace_unavailable"
+    normalized_search_session_id = _guided_normalize_whitespace(search_session_id)
+    if not normalized_search_session_id:
+        return None, "missing_session_id"
+    try:
+        record = workspace_registry.get(normalized_search_session_id)
+    except Exception:
+        return None, "session_not_found"
+
+    normalized_source_id = _guided_normalize_whitespace(source_id)
+    if not normalized_source_id:
+        return None, "empty_source_id"
+
+    direct = _find_record_source(
+        workspace_registry=workspace_registry,
+        search_session_id=normalized_search_session_id,
+        source_id=normalized_source_id,
+    )
+    if direct is not None:
+        return direct, "exact_id"
+
+    sources = _guided_record_source_candidates(record)
+    if not sources:
+        return None, "no_session_sources"
+
+    index_match = re.fullmatch(r"(?:source|src|lead|paper)?\s*[-_#]?\s*(\d{1,3})", normalized_source_id, re.IGNORECASE)
+    if index_match:
+        index = int(index_match.group(1))
+        if 1 <= index <= len(sources):
+            return sources[index - 1], "index_alias"
+
+    lowered_source_id = normalized_source_id.lower()
+    for source in sources:
+        for candidate in (
+            source.get("sourceId"),
+            source.get("citationText"),
+            source.get("canonicalUrl"),
+            source.get("retrievedUrl"),
+            source.get("title"),
+        ):
+            normalized_candidate = _guided_normalize_whitespace(candidate).lower()
+            if normalized_candidate and normalized_candidate == lowered_source_id:
+                return source, "casefold_exact"
+
+    partial_matches = [
+        source
+        for source in sources
+        if lowered_source_id in _guided_normalize_whitespace(source.get("title")).lower()
+        or lowered_source_id in _guided_normalize_whitespace(source.get("canonicalUrl")).lower()
+        or lowered_source_id in _guided_normalize_whitespace(source.get("citationText")).lower()
+    ]
+    if len(partial_matches) == 1:
+        return partial_matches[0], "unique_partial_match"
+
+    return None, "unresolved"
+
+
 def _find_record_source(
     *,
     workspace_registry: Any,
-    search_session_id: str,
+    search_session_id: str | None,
     source_id: str,
 ) -> dict[str, Any] | None:
     if workspace_registry is None:
         return None
-    record = workspace_registry.get(search_session_id)
+    normalized_search_session_id = _guided_normalize_whitespace(search_session_id)
+    if not normalized_search_session_id:
+        return None
+    record = workspace_registry.get(normalized_search_session_id)
     payload = record.payload if isinstance(record.payload, dict) else {}
+    normalized_source_id = _guided_normalize_whitespace(source_id)
+    if not normalized_source_id:
+        return None
     for source in payload.get("sources") or []:
-        if isinstance(source, dict) and str(source.get("sourceId") or "").strip() == source_id:
+        if isinstance(source, dict) and normalized_source_id in {
+            _guided_normalize_whitespace(source.get("sourceId")),
+            _guided_normalize_whitespace(source.get("sourceAlias")),
+        }:
             return source
     for source in payload.get("structuredSources") or []:
         if not isinstance(source, dict):
             continue
         candidate_ids = {
-            str(source.get("sourceId") or "").strip(),
-            str(source.get("citationText") or "").strip(),
-            str(source.get("canonicalUrl") or "").strip(),
+            _guided_normalize_whitespace(source.get("sourceId")),
+            _guided_normalize_whitespace(source.get("citationText")),
+            _guided_normalize_whitespace(source.get("canonicalUrl")),
         }
-        if source_id in candidate_ids:
+        if normalized_source_id in candidate_ids:
             return _guided_source_record_from_structured_source(source, index=1)
     for index, paper in enumerate(record.papers, start=1):
         if not isinstance(paper, dict):
             continue
         candidate_ids = {
-            str(paper.get("paperId") or "").strip(),
-            str(paper.get("sourceId") or "").strip(),
-            str(paper.get("canonicalId") or "").strip(),
-            str(paper.get("recommendedExpansionId") or "").strip(),
+            _guided_normalize_whitespace(paper.get("paperId")),
+            _guided_normalize_whitespace(paper.get("sourceId")),
+            _guided_normalize_whitespace(paper.get("canonicalId")),
+            _guided_normalize_whitespace(paper.get("recommendedExpansionId")),
         }
-        if source_id in candidate_ids:
+        if normalized_source_id in candidate_ids:
             query = str(record.query or payload.get("query") or "")
             return _guided_source_record_from_paper(query, paper, index=index)
     return None
@@ -1289,12 +2160,15 @@ def _guided_session_findings(payload: dict[str, Any], sources: list[dict[str, An
 def _guided_session_state(
     *,
     workspace_registry: Any,
-    search_session_id: str,
+    search_session_id: str | None,
 ) -> dict[str, Any] | None:
     if workspace_registry is None:
         return None
+    normalized_search_session_id = _guided_normalize_whitespace(search_session_id)
+    if not normalized_search_session_id:
+        return None
     try:
-        record = workspace_registry.get(search_session_id)
+        record = workspace_registry.get(normalized_search_session_id)
     except Exception:
         return None
     payload = record.payload if isinstance(record.payload, dict) else {}
@@ -1346,11 +2220,20 @@ def _guided_session_state(
             evidence_gaps=evidence_gaps,
             coverage=coverage,
             failure_summary=failure_summary,
+            source_count=len(sources),
         ),
         "nextActions": payload.get("nextActions")
         or _guided_next_actions(
             search_session_id=record.search_session_id,
             status=status,
+            has_sources=bool(sources),
+        ),
+        "resultState": payload.get("resultState")
+        or _guided_result_state(
+            status=status,
+            sources=sources,
+            evidence_gaps=evidence_gaps,
+            search_session_id=record.search_session_id,
         ),
     }
 
@@ -1454,7 +2337,96 @@ def _guided_follow_up_introspection_facets(question: str) -> set[str]:
         )
     ):
         facets.add("source_overview")
+    if re.search(r"\bsource(?:\s*id)?\b", text):
+        facets.add("specific_source")
     return facets
+
+
+def _guided_extract_source_reference_from_question(question: str) -> str | None:
+    normalized_question = _guided_normalize_whitespace(question)
+    if not normalized_question:
+        return None
+    patterns = (
+        re.compile(r"\bsource(?:\s*id)?\s*[:=]?\s*['\"]?(?P<id>[A-Za-z0-9._:/#-]{2,})['\"]?", re.IGNORECASE),
+        re.compile(r"\binspect\s+source\s+['\"]?(?P<id>[A-Za-z0-9._:/#-]{2,})['\"]?", re.IGNORECASE),
+    )
+    for pattern in patterns:
+        match = pattern.search(normalized_question)
+        if match:
+            candidate = _guided_normalize_whitespace(match.group("id"))
+            if candidate:
+                return candidate
+    return None
+
+
+def _guided_is_usable_answer_text(value: Any) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return False
+    return bool(re.search(r"[A-Za-z0-9]", text))
+
+
+def _guided_select_follow_up_source(question: str, sources: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not sources:
+        return None
+    if len(sources) == 1:
+        return sources[0]
+
+    normalized_question = _guided_normalize_whitespace(question).lower()
+    for source in sources:
+        title = _guided_normalize_whitespace(source.get("title")).lower()
+        if title and title in normalized_question:
+            return source
+
+    source_reference = _guided_extract_source_reference_from_question(question)
+    if source_reference:
+        lowered_reference = source_reference.lower()
+        for source in sources:
+            if lowered_reference == _guided_normalize_whitespace(source.get("sourceId")).lower():
+                return source
+            if lowered_reference == _guided_normalize_whitespace(source.get("sourceAlias")).lower():
+                return source
+    return None
+
+
+def _guided_source_metadata_answers(question: str, sources: list[dict[str, Any]]) -> list[str]:
+    source = _guided_select_follow_up_source(question, sources)
+    if source is None:
+        return []
+
+    normalized_question = _guided_normalize_whitespace(question).lower()
+    raw_citation = source.get("citation")
+    citation: dict[str, Any] = cast(dict[str, Any], raw_citation) if isinstance(raw_citation, dict) else {}
+    answers: list[str] = []
+
+    if any(marker in normalized_question for marker in ("author", "authors", "who wrote", "written by")):
+        raw_authors = citation.get("authors")
+        authors: list[Any] = raw_authors if isinstance(raw_authors, list) else []
+        author_names = [str(author).strip() for author in authors if str(author).strip()]
+        if author_names:
+            answers.append("Authors listed for this source: " + ", ".join(author_names) + ".")
+
+    if any(marker in normalized_question for marker in ("venue", "journal", "publisher", "published in")):
+        venue = str(citation.get("journalOrPublisher") or "").strip()
+        if venue:
+            answers.append(f"Venue listed for this source: {venue}.")
+
+    if any(marker in normalized_question for marker in ("doi", "identifier")):
+        doi = str(citation.get("doi") or "").strip()
+        if doi:
+            answers.append(f"DOI listed for this source: {doi}.")
+
+    if any(marker in normalized_question for marker in ("year", "publication year", "published")):
+        year = str(citation.get("year") or source.get("date") or "").strip()
+        if year:
+            answers.append(f"Publication year listed for this source: {year}.")
+
+    if any(marker in normalized_question for marker in ("title", "which paper", "which source", "what paper")):
+        title = str(source.get("title") or source.get("sourceId") or "").strip()
+        if title:
+            answers.append(f"Matched source title: {title}.")
+
+    return answers
 
 
 def _answer_follow_up_from_session_state(
@@ -1463,9 +2435,6 @@ def _answer_follow_up_from_session_state(
     session_state: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
     if session_state is None:
-        return None
-    facets = _guided_follow_up_introspection_facets(question)
-    if not facets:
         return None
     answer_parts: list[str] = []
     coverage = cast(dict[str, Any] | None, session_state.get("coverage")) or {}
@@ -1476,6 +2445,12 @@ def _answer_follow_up_from_session_state(
     ]
     sources = [source for source in session_state.get("sources") or [] if isinstance(source, dict)]
     trust_summary = cast(dict[str, Any] | None, session_state.get("trustSummary")) or {}
+    metadata_answers = _guided_source_metadata_answers(question, sources)
+    facets = _guided_follow_up_introspection_facets(question)
+    if not facets and not metadata_answers:
+        return None
+
+    answer_parts.extend(metadata_answers)
 
     if "coverage" in facets:
         attempted = list(coverage.get("providersAttempted") or [])
@@ -1579,6 +2554,40 @@ def _answer_follow_up_from_session_state(
             else:
                 answer_parts.append("No saved sources were available for this session.")
 
+    if "specific_source" in facets:
+        source_reference = _guided_extract_source_reference_from_question(question)
+        if source_reference:
+            source = None
+            match_type = "unresolved"
+            lower_reference = source_reference.lower()
+            session_leads = [lead for lead in session_state.get("unverifiedLeads") or [] if isinstance(lead, dict)]
+            source_matches = [
+                candidate
+                for candidate in sources + session_leads
+                if (
+                    lower_reference == _guided_normalize_whitespace(candidate.get("sourceId")).lower()
+                    or lower_reference in _guided_normalize_whitespace(candidate.get("title")).lower()
+                    or lower_reference in _guided_normalize_whitespace(candidate.get("canonicalUrl")).lower()
+                )
+            ]
+            if len(source_matches) == 1:
+                source = source_matches[0]
+                match_type = "session_local_match"
+            if source is not None:
+                source_title = str(source.get("title") or source.get("sourceId") or "requested source")
+                source_provider = str(source.get("provider") or "unknown provider")
+                source_relevance = str(source.get("topicalRelevance") or "unknown relevance")
+                answer_parts.append(
+                    f"Source {source_title} ({source_provider}) was matched via {match_type} "
+                    f"with relevance {source_relevance}."
+                )
+            else:
+                answer_parts.append(
+                    f"No saved source matched '{source_reference}' in this session. "
+                    "Use inspect_source with an exact sourceId for direct inspection."
+                )
+
+    answer_parts = [part.strip() for part in answer_parts if _guided_is_usable_answer_text(part)]
     if not answer_parts:
         return None
 
@@ -1598,6 +2607,13 @@ def _answer_follow_up_from_session_state(
         "failureSummary": session_state["failureSummary"],
         "resultMeaning": session_state["resultMeaning"],
         "nextActions": session_state["nextActions"],
+        "resultState": session_state.get("resultState")
+        or _guided_result_state(
+            status="answered",
+            sources=sources,
+            evidence_gaps=evidence_gaps,
+            search_session_id=str(session_state.get("searchSessionId") or ""),
+        ),
     }
 
 
@@ -1732,6 +2748,7 @@ async def dispatch_tool(
         raw = await _dispatch_internal("resolve_citation", {"citation": resolve_args.reference})
         best_match = raw.get("bestMatch")
         alternatives = list(raw.get("alternatives") or [])
+        resolution_confidence = str(raw.get("resolutionConfidence") or "low")
         resolution_type = "title_fragment"
         if parsed.looks_like_regulatory:
             resolution_type = "regulatory_reference"
@@ -1743,11 +2760,7 @@ async def dispatch_tool(
         if parsed.looks_like_regulatory and best_match is None:
             status = "regulatory_primary_source"
         elif best_match is not None:
-            status = (
-                "resolved"
-                if str(raw.get("resolutionConfidence") or "low") == "high" or not alternatives
-                else "multiple_candidates"
-            )
+            status = "resolved" if resolution_confidence in {"high", "medium"} else "multiple_candidates"
         elif alternatives:
             status = "multiple_candidates"
         next_actions: list[str] = []
@@ -1772,17 +2785,21 @@ async def dispatch_tool(
             "status": status,
             "bestMatch": best_match,
             "alternatives": alternatives,
+            "resolutionConfidence": resolution_confidence,
             "nextActions": next_actions,
             "searchSessionId": raw.get("searchSessionId"),
         }
 
     if name == "research":
-        research_args = cast(ResearchArgs, TOOL_INPUT_MODELS[name].model_validate(arguments))
+        normalized_research_arguments, research_normalization = _guided_normalize_research_arguments(arguments)
+        research_args = cast(ResearchArgs, TOOL_INPUT_MODELS[name].model_validate(normalized_research_arguments))
         intent = "discovery"
-        if detect_regulatory_intent(research_args.query, research_args.focus):
-            intent = "regulatory"
-        elif looks_like_paper_identifier(research_args.query) or looks_like_citation_query(research_args.query):
+        if _guided_is_known_item_query(research_args.query):
             intent = "known_item"
+        elif _guided_is_mixed_intent_query(research_args.query, research_args.focus):
+            intent = "mixed"
+        elif detect_regulatory_intent(research_args.query, research_args.focus):
+            intent = "regulatory"
 
         if intent == "known_item":
             resolved = await _dispatch_internal("resolve_reference", {"reference": research_args.query})
@@ -1824,78 +2841,163 @@ async def dispatch_tool(
                     evidence_gaps=evidence_gaps,
                     coverage=None,
                     failure_summary=failure_summary,
+                    source_count=len(sources),
                 ),
                 "nextActions": _guided_next_actions(
                     search_session_id=cast(str | None, resolved.get("searchSessionId")),
                     status=status,
+                    has_sources=bool(sources),
                 ),
                 "clarification": None,
+                "resultState": _guided_result_state(
+                    status=status,
+                    sources=sources,
+                    evidence_gaps=evidence_gaps,
+                    search_session_id=cast(str | None, resolved.get("searchSessionId")),
+                ),
+                "inputNormalization": _guided_normalization_payload(research_normalization),
             }
 
         if agentic_runtime is not None:
-            smart = await _dispatch_internal(
-                "search_papers_smart",
-                {
-                    "query": research_args.query,
-                    "limit": research_args.limit,
-                    "year": research_args.year,
-                    "venue": research_args.venue,
-                    "focus": research_args.focus,
-                    "latencyProfile": research_args.latency_profile,
-                    "providerBudget": {"allowPaidProviders": False},
-                },
+            smart_request = {
+                "query": research_args.query,
+                "limit": research_args.limit,
+                "year": research_args.year,
+                "venue": research_args.venue,
+                "focus": research_args.focus,
+                "latencyProfile": research_args.latency_profile,
+                "providerBudget": {"allowPaidProviders": False},
+            }
+            smart_runs: list[dict[str, Any]] = []
+            try:
+                if intent == "mixed":
+                    smart_runs.append(
+                        await _dispatch_internal(
+                            "search_papers_smart",
+                            {
+                                **smart_request,
+                                "mode": "regulatory",
+                            },
+                        )
+                    )
+                    smart_runs.append(
+                        await _dispatch_internal(
+                            "search_papers_smart",
+                            {
+                                **smart_request,
+                                "mode": "review",
+                            },
+                        )
+                    )
+                else:
+                    smart_runs.append(
+                        await _dispatch_internal(
+                            "search_papers_smart",
+                            {
+                                **smart_request,
+                                "mode": "regulatory" if intent == "regulatory" else "auto",
+                            },
+                        )
+                    )
+                if any(not isinstance(smart, dict) for smart in smart_runs):
+                    raise ValueError("search_papers_smart returned a non-object payload.")
+            except Exception as error:
+                return _guided_machine_failure_payload(
+                    search_session_id=None,
+                    error=error,
+                    normalization=research_normalization,
+                )
+
+            sources = _guided_dedupe_source_records(
+                [
+                    _guided_source_record_from_structured_source(source, index=index)
+                    for smart in smart_runs
+                    for index, source in enumerate(smart.get("structuredSources") or [], start=1)
+                    if isinstance(source, dict)
+                ]
             )
-            sources = [
-                _guided_source_record_from_structured_source(source, index=index)
-                for index, source in enumerate(smart.get("structuredSources") or [], start=1)
-                if isinstance(source, dict)
-            ]
             verified_findings = _guided_findings_from_sources(sources)
-            evidence_gaps = list(smart.get("evidenceGaps") or [])
-            unverified_leads = [
-                _guided_source_record_from_structured_source(source, index=index)
-                for index, source in enumerate(smart.get("candidateLeads") or [], start=1)
-                if isinstance(source, dict)
-            ] or _guided_unverified_leads_from_sources(sources)
+            evidence_gaps = list(
+                dict.fromkeys(
+                    str(gap).strip()
+                    for smart in smart_runs
+                    for gap in (smart.get("evidenceGaps") or [])
+                    if str(gap).strip()
+                )
+            )
+            unverified_leads = _guided_dedupe_source_records(
+                [
+                    _guided_source_record_from_structured_source(source, index=index)
+                    for smart in smart_runs
+                    for index, source in enumerate(smart.get("candidateLeads") or [], start=1)
+                    if isinstance(source, dict)
+                ]
+            ) or _guided_unverified_leads_from_sources(sources)
+            merged_coverage = _guided_merge_coverage_summaries(
+                *(cast(dict[str, Any] | None, smart.get("coverageSummary")) for smart in smart_runs)
+            )
+            merged_failure_summary = _guided_merge_failure_summaries(
+                *(cast(dict[str, Any] | None, smart.get("failureSummary")) for smart in smart_runs)
+            )
+            derived_intent = (
+                "mixed" if intent == "mixed" else str(smart_runs[0].get("strategyMetadata", {}).get("intent") or intent)
+            )
+            status_intent = (
+                "regulatory"
+                if derived_intent == "mixed" and any(source.get("isPrimarySource") for source in sources)
+                else derived_intent
+            )
             status = _guided_research_status(
-                intent=str(smart.get("strategyMetadata", {}).get("intent") or intent),
+                intent=status_intent,
                 sources=sources,
                 findings=verified_findings,
-                coverage_summary=cast(dict[str, Any] | None, smart.get("coverageSummary")),
-                failure_summary=cast(dict[str, Any] | None, smart.get("failureSummary")),
-                clarification=cast(dict[str, Any] | None, smart.get("clarification")),
+                unverified_leads_count=len(unverified_leads),
+                coverage_summary=merged_coverage,
+                failure_summary=merged_failure_summary,
+                clarification=cast(dict[str, Any] | None, smart_runs[0].get("clarification")),
             )
             failure_summary = _guided_failure_summary(
-                failure_summary=cast(dict[str, Any] | None, smart.get("failureSummary")),
+                failure_summary=merged_failure_summary,
                 status=status,
                 sources=sources,
                 evidence_gaps=evidence_gaps,
             )
+            primary_smart = smart_runs[0]
+            search_session_id = cast(str | None, primary_smart.get("searchSessionId"))
             return {
-                "intent": str(smart.get("strategyMetadata", {}).get("intent") or intent),
+                "intent": derived_intent,
                 "status": status,
-                "searchSessionId": smart.get("searchSessionId"),
-                "summary": _guided_summary(intent, status, verified_findings, sources),
+                "searchSessionId": search_session_id,
+                "summary": _guided_summary(derived_intent, status, verified_findings, sources),
                 "verifiedFindings": verified_findings,
                 "sources": sources,
                 "unverifiedLeads": unverified_leads,
                 "evidenceGaps": evidence_gaps,
                 "trustSummary": _guided_trust_summary(sources, evidence_gaps),
-                "coverage": smart.get("coverageSummary"),
+                "coverage": merged_coverage,
                 "failureSummary": failure_summary,
                 "resultMeaning": _guided_result_meaning(
                     status=status,
                     verified_findings=verified_findings,
                     evidence_gaps=evidence_gaps,
-                    coverage=cast(dict[str, Any] | None, smart.get("coverageSummary")),
+                    coverage=merged_coverage,
                     failure_summary=failure_summary,
+                    source_count=len(sources),
                 ),
                 "nextActions": _guided_next_actions(
-                    search_session_id=cast(str | None, smart.get("searchSessionId")),
+                    search_session_id=search_session_id,
                     status=status,
+                    has_sources=bool(sources),
                 ),
-                "clarification": smart.get("clarification"),
-                "regulatoryTimeline": smart.get("regulatoryTimeline"),
+                "clarification": primary_smart.get("clarification"),
+                "regulatoryTimeline": primary_smart.get("regulatoryTimeline"),
+                "resultState": _guided_result_state(
+                    status=status,
+                    sources=sources,
+                    evidence_gaps=evidence_gaps,
+                    search_session_id=search_session_id,
+                ),
+                "inputNormalization": _guided_normalization_payload(research_normalization),
             }
 
         raw = await _dispatch_internal(
@@ -1919,6 +3021,7 @@ async def dispatch_tool(
             intent=intent,
             sources=sources,
             findings=verified_findings,
+            unverified_leads_count=len(unverified_leads),
             coverage_summary=cast(dict[str, Any] | None, raw.get("coverageSummary")),
             failure_summary=cast(dict[str, Any] | None, raw.get("failureSummary")),
             clarification=None,
@@ -1947,16 +3050,32 @@ async def dispatch_tool(
                 evidence_gaps=evidence_gaps,
                 coverage=cast(dict[str, Any] | None, raw.get("coverageSummary")),
                 failure_summary=failure_summary,
+                source_count=len(sources),
             ),
             "nextActions": _guided_next_actions(
                 search_session_id=cast(str | None, raw.get("searchSessionId")),
                 status=status,
+                has_sources=bool(sources),
             ),
             "clarification": None,
+            "resultState": _guided_result_state(
+                status=status,
+                sources=sources,
+                evidence_gaps=evidence_gaps,
+                search_session_id=cast(str | None, raw.get("searchSessionId")),
+            ),
+            "inputNormalization": _guided_normalization_payload(research_normalization),
         }
 
     if name == "follow_up_research":
-        follow_up_args = cast(FollowUpResearchArgs, TOOL_INPUT_MODELS[name].model_validate(arguments))
+        normalized_follow_up_arguments, follow_up_normalization = _guided_normalize_follow_up_arguments(
+            arguments,
+            workspace_registry=workspace_registry,
+        )
+        follow_up_args = cast(
+            FollowUpResearchArgs,
+            TOOL_INPUT_MODELS[name].model_validate(normalized_follow_up_arguments),
+        )
         session_state = _guided_session_state(
             workspace_registry=workspace_registry,
             search_session_id=follow_up_args.search_session_id,
@@ -1966,7 +3085,61 @@ async def dispatch_tool(
             session_state=session_state,
         )
         if session_answer is not None:
+            session_answer["inputNormalization"] = _guided_normalization_payload(follow_up_normalization)
             return session_answer
+        if not follow_up_args.search_session_id:
+            evidence_gaps = ["A unique saved search session could not be identified for this follow-up question."]
+            failure_summary = _guided_failure_summary(
+                failure_summary={
+                    "outcome": "needs_clarification",
+                    "whatFailed": "follow_up_session_inference",
+                    "whatStillWorked": (
+                        "The server preserved a safe failure state instead of binding to the wrong session."
+                    ),
+                    "fallbackAttempted": False,
+                    "fallbackMode": None,
+                    "primaryPathFailureReason": "ambiguous_or_missing_search_session",
+                    "completenessImpact": evidence_gaps[0],
+                    "recommendedNextAction": "research",
+                },
+                status="partial",
+                sources=[],
+                evidence_gaps=evidence_gaps,
+            )
+            return {
+                "searchSessionId": None,
+                "answerStatus": "insufficient_evidence",
+                "answer": None,
+                "evidence": [],
+                "unsupportedAsks": [follow_up_args.question],
+                "followUpQuestions": [],
+                "sources": [],
+                "unverifiedLeads": [],
+                "verifiedFindings": [],
+                "evidenceGaps": evidence_gaps,
+                "trustSummary": _guided_trust_summary([], evidence_gaps),
+                "coverage": None,
+                "failureSummary": failure_summary,
+                "resultMeaning": _guided_result_meaning(
+                    status="partial",
+                    verified_findings=[],
+                    evidence_gaps=evidence_gaps,
+                    coverage=None,
+                    failure_summary=failure_summary,
+                    source_count=0,
+                ),
+                "nextActions": [
+                    "Provide an explicit searchSessionId from a prior research result.",
+                    "Run research again if you need a fresh grounded session to follow up on.",
+                ],
+                "resultState": _guided_result_state(
+                    status="partial",
+                    sources=[],
+                    evidence_gaps=evidence_gaps,
+                    search_session_id=None,
+                ),
+                "inputNormalization": _guided_normalization_payload(follow_up_normalization),
+            }
         if agentic_runtime is None:
             evidence_gaps = [follow_up_args.question]
             failure_summary = _guided_failure_summary(
@@ -2004,19 +3177,69 @@ async def dispatch_tool(
                     evidence_gaps=evidence_gaps,
                     coverage=None,
                     failure_summary=failure_summary,
+                    source_count=0,
                 ),
                 "nextActions": _guided_next_actions(
                     search_session_id=follow_up_args.search_session_id,
                     status="partial",
+                    has_sources=False,
                 ),
+                "resultState": _guided_result_state(
+                    status="partial",
+                    sources=[],
+                    evidence_gaps=evidence_gaps,
+                    search_session_id=follow_up_args.search_session_id,
+                ),
+                "inputNormalization": _guided_normalization_payload(follow_up_normalization),
             }
-        ask = await _dispatch_internal(
-            "ask_result_set",
-            {
+        try:
+            ask = await _dispatch_internal(
+                "ask_result_set",
+                {
+                    "searchSessionId": follow_up_args.search_session_id,
+                    "question": follow_up_args.question,
+                },
+            )
+            if not isinstance(ask, dict):
+                raise ValueError("ask_result_set returned a non-object payload.")
+        except Exception as error:
+            machine_failure = _guided_machine_failure_payload(
+                search_session_id=follow_up_args.search_session_id,
+                error=error,
+                normalization=follow_up_normalization,
+            )
+            return {
                 "searchSessionId": follow_up_args.search_session_id,
-                "question": follow_up_args.question,
-            },
-        )
+                "answerStatus": "insufficient_evidence",
+                "answer": None,
+                "evidence": [],
+                "unsupportedAsks": [follow_up_args.question],
+                "followUpQuestions": [],
+                "verifiedFindings": [],
+                "sources": [],
+                "unverifiedLeads": [],
+                "evidenceGaps": machine_failure.get("evidenceGaps") or [],
+                "trustSummary": machine_failure.get("trustSummary") or _guided_trust_summary([], []),
+                "coverage": machine_failure.get("coverage"),
+                "failureSummary": machine_failure.get("failureSummary"),
+                "resultMeaning": machine_failure.get("resultMeaning"),
+                "nextActions": machine_failure.get("nextActions")
+                or _guided_next_actions(
+                    search_session_id=follow_up_args.search_session_id,
+                    status="partial",
+                    has_sources=False,
+                ),
+                "resultState": machine_failure.get("resultState")
+                or _guided_result_state(
+                    status="partial",
+                    sources=[],
+                    evidence_gaps=list(machine_failure.get("evidenceGaps") or []),
+                    search_session_id=follow_up_args.search_session_id,
+                ),
+                "machineFailure": machine_failure.get("machineFailure"),
+                "inputNormalization": machine_failure.get("inputNormalization")
+                or _guided_normalization_payload(follow_up_normalization),
+            }
         sources = [
             _guided_source_record_from_structured_source(source, index=index)
             for index, source in enumerate(ask.get("structuredSources") or [], start=1)
@@ -2057,31 +3280,83 @@ async def dispatch_tool(
                 evidence_gaps=evidence_gaps,
                 coverage=cast(dict[str, Any] | None, ask.get("coverageSummary")),
                 failure_summary=failure_summary,
+                source_count=len(sources),
             ),
             "nextActions": _guided_next_actions(
                 search_session_id=follow_up_args.search_session_id,
                 status=guided_status,
+                has_sources=bool(sources),
             ),
+            "resultState": _guided_result_state(
+                status=guided_status,
+                sources=sources,
+                evidence_gaps=evidence_gaps,
+                search_session_id=follow_up_args.search_session_id,
+            ),
+            "inputNormalization": _guided_normalization_payload(follow_up_normalization),
         }
         session_answer = _answer_follow_up_from_session_state(
             question=follow_up_args.question,
             session_state=session_state,
         )
+        if answer_status == "answered" and not _guided_is_usable_answer_text(ask.get("answer")):
+            if session_answer is not None:
+                session_answer["inputNormalization"] = _guided_normalization_payload(follow_up_normalization)
+                return session_answer
+            response["answerStatus"] = "insufficient_evidence"
+            response["answer"] = None
+            response["resultMeaning"] = _guided_result_meaning(
+                status="partial",
+                verified_findings=verified_findings,
+                evidence_gaps=evidence_gaps,
+                coverage=cast(dict[str, Any] | None, ask.get("coverageSummary")),
+                failure_summary=failure_summary,
+                source_count=len(sources),
+            )
+            response["resultState"] = _guided_result_state(
+                status="partial",
+                sources=sources,
+                evidence_gaps=evidence_gaps,
+                search_session_id=follow_up_args.search_session_id,
+            )
+            return response
         if answer_status != "answered" and session_answer is not None:
+            session_answer["inputNormalization"] = _guided_normalization_payload(follow_up_normalization)
             return session_answer
         return response
 
     if name == "inspect_source":
-        inspect_args = cast(InspectSourceArgs, TOOL_INPUT_MODELS[name].model_validate(arguments))
-        source = _find_record_source(
+        normalized_inspect_arguments, inspect_normalization = _guided_normalize_inspect_arguments(
+            arguments,
+            workspace_registry=workspace_registry,
+        )
+        inspect_args = cast(InspectSourceArgs, TOOL_INPUT_MODELS[name].model_validate(normalized_inspect_arguments))
+        if not inspect_args.search_session_id:
+            raise ValueError(
+                "inspect_source could not infer a unique searchSessionId. Provide an explicit searchSessionId from a "
+                "prior research result."
+            )
+        source, match_type = _find_record_source_with_resolution(
             workspace_registry=workspace_registry,
             search_session_id=inspect_args.search_session_id,
             source_id=inspect_args.source_id,
         )
         if source is None:
+            available_ids: list[str] = []
+            if workspace_registry is not None and inspect_args.search_session_id:
+                try:
+                    record = workspace_registry.get(inspect_args.search_session_id)
+                    available_ids = [
+                        str(candidate.get("sourceId") or "").strip()
+                        for candidate in _guided_record_source_candidates(record)
+                        if str(candidate.get("sourceId") or "").strip()
+                    ][:8]
+                except Exception:
+                    available_ids = []
+            suggestions = f" Available sourceId values: {', '.join(available_ids)}." if available_ids else ""
             raise ValueError(
                 f"Could not find sourceId {inspect_args.source_id!r} in searchSessionId "
-                f"{inspect_args.search_session_id!r}."
+                f"{inspect_args.search_session_id!r}.{suggestions}"
             )
         return {
             "searchSessionId": inspect_args.search_session_id,
@@ -2090,7 +3365,20 @@ async def dispatch_tool(
             "nextActions": _guided_next_actions(
                 search_session_id=inspect_args.search_session_id,
                 status="succeeded",
+                has_sources=True,
             ),
+            "sourceResolution": {
+                "requestedSourceId": inspect_args.source_id,
+                "resolvedSourceId": source.get("sourceId"),
+                "matchType": match_type,
+            },
+            "resultState": _guided_result_state(
+                status="succeeded",
+                sources=[source],
+                evidence_gaps=[],
+                search_session_id=inspect_args.search_session_id,
+            ),
+            "inputNormalization": _guided_normalization_payload(inspect_normalization),
         }
 
     if name == "search_papers_smart":

--- a/paper_chaser_mcp/models/tools.py
+++ b/paper_chaser_mcp/models/tools.py
@@ -174,9 +174,14 @@ class ResearchArgs(ToolArgsModel):
 
 
 class FollowUpResearchArgs(ToolArgsModel):
-    search_session_id: str = Field(
+    search_session_id: str | None = Field(
+        default=None,
         alias="searchSessionId",
-        description="searchSessionId returned by the guided research tool.",
+        description=(
+            "Optional searchSessionId returned by the guided research tool. "
+            "When omitted, the server will reuse the most recent compatible saved session only if that choice is "
+            "unambiguous."
+        ),
     )
     question: str = Field(description="Grounded follow-up question about the saved research result set.")
 
@@ -186,13 +191,18 @@ class ResolveReferenceArgs(ToolArgsModel):
 
 
 class InspectSourceArgs(ToolArgsModel):
-    search_session_id: str = Field(
+    search_session_id: str | None = Field(
+        default=None,
         alias="searchSessionId",
-        description="searchSessionId returned by the guided research tool.",
+        description=(
+            "Optional searchSessionId returned by the guided research tool. "
+            "When omitted, the server will reuse the most recent compatible saved session only if that choice is "
+            "unambiguous."
+        ),
     )
     source_id: str = Field(
         alias="sourceId",
-        description="Canonical sourceId returned in the guided research sources list.",
+        description="Canonical sourceId or session-local source alias returned in the guided research sources list.",
     )
 
 

--- a/paper_chaser_mcp/server.py
+++ b/paper_chaser_mcp/server.py
@@ -346,7 +346,7 @@ def _build_signature(model: Any) -> tuple[Signature, dict[str, Any]]:
         parameters.append(
             Parameter(
                 parameter_name,
-                Parameter.POSITIONAL_OR_KEYWORD,
+                Parameter.KEYWORD_ONLY,
                 annotation=model_field.annotation,
                 default=_parameter_default(model_field),
             )
@@ -355,7 +355,7 @@ def _build_signature(model: Any) -> tuple[Signature, dict[str, Any]]:
     parameters.append(
         Parameter(
             "ctx",
-            Parameter.POSITIONAL_OR_KEYWORD,
+            Parameter.KEYWORD_ONLY,
             annotation=Context,
             default=None,
         )

--- a/tests/test_citation_repair.py
+++ b/tests/test_citation_repair.py
@@ -6,7 +6,10 @@ from paper_chaser_mcp import server
 from paper_chaser_mcp.agentic import WorkspaceRegistry
 from paper_chaser_mcp.citation_repair import (
     RankedCitationCandidate,
+    _classify_resolution_confidence,
     _filtered_alternative_candidates,
+    _normalize_identifier_for_openalex,
+    _normalize_identifier_for_semantic_scholar,
     parse_citation,
     resolve_citation,
 )
@@ -416,3 +419,104 @@ async def test_resolve_citation_regulatory_input_redirects_to_regulatory_tools_w
     assert payload["inferredFields"]["likelyOutputType"] == "regulatory_primary_source"
     assert "federal register" in payload["message"].lower()
     assert semantic.calls == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_citation_bare_doi_identifier_resolution_is_high_confidence() -> None:
+    semantic = RecordingSemanticClient()
+
+    payload = await resolve_citation(
+        citation="10.1038/nrn3241",
+        max_candidates=3,
+        client=semantic,
+        enable_core=False,
+        enable_semantic_scholar=True,
+        enable_openalex=False,
+        enable_arxiv=False,
+        enable_serpapi=False,
+        core_client=None,
+        openalex_client=None,
+        arxiv_client=None,
+        serpapi_client=None,
+    )
+
+    assert payload["bestMatch"]["paper"]["paperId"] == "DOI:10.1038/nrn3241"
+    assert payload["resolutionConfidence"] == "high"
+    assert semantic.calls[0] == ("get_paper_details", {"paper_id": "DOI:10.1038/nrn3241", "fields": None})
+
+
+@pytest.mark.asyncio
+async def test_resolve_citation_semantic_scholar_url_resolution_is_high_confidence() -> None:
+    semantic = RecordingSemanticClient()
+    paper_url = (
+        "https://www.semanticscholar.org/paper/Attention-Is-All-You-Need/204e3073870fae3d05bcbc2f6a8e263d9b72e776"
+    )
+
+    payload = await resolve_citation(
+        citation=paper_url,
+        max_candidates=3,
+        client=semantic,
+        enable_core=False,
+        enable_semantic_scholar=True,
+        enable_openalex=False,
+        enable_arxiv=False,
+        enable_serpapi=False,
+        core_client=None,
+        openalex_client=None,
+        arxiv_client=None,
+        serpapi_client=None,
+    )
+
+    assert payload["bestMatch"]["paper"]["paperId"] == "204e3073870fae3d05bcbc2f6a8e263d9b72e776"
+    assert payload["resolutionConfidence"] == "high"
+    assert semantic.calls[0] == (
+        "get_paper_details",
+        {"paper_id": "204e3073870fae3d05bcbc2f6a8e263d9b72e776", "fields": None},
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_citation_arxiv_identifier_resolution_is_high_confidence() -> None:
+    semantic = RecordingSemanticClient()
+
+    payload = await resolve_citation(
+        citation="arXiv:1706.03762",
+        max_candidates=3,
+        client=semantic,
+        enable_core=False,
+        enable_semantic_scholar=True,
+        enable_openalex=False,
+        enable_arxiv=False,
+        enable_serpapi=False,
+        core_client=None,
+        openalex_client=None,
+        arxiv_client=None,
+        serpapi_client=None,
+    )
+
+    assert payload["bestMatch"]["paper"]["paperId"] == "ARXIV:1706.03762"
+    assert payload["resolutionConfidence"] == "high"
+    assert semantic.calls[0] == ("get_paper_details", {"paper_id": "ARXIV:1706.03762", "fields": None})
+
+
+def test_classify_resolution_confidence_identifier_match_remains_high() -> None:
+    assert (
+        _classify_resolution_confidence(
+            best_score=0.61,
+            runner_up_score=0.0,
+            matched_fields=["identifier"],
+            conflicting_fields=["year", "author"],
+            resolution_strategy="identifier",
+        )
+        == "high"
+    )
+
+
+def test_identifier_normalizers_cover_openalex_and_generic_url_branches() -> None:
+    assert _normalize_identifier_for_openalex("doi:10.1038/nrn3241", "doi") == "10.1038/nrn3241"
+    assert _normalize_identifier_for_openalex("https://openalex.org/W12345", "url") == "W12345"
+    assert _normalize_identifier_for_openalex("https://example.org/paper", "url") is None
+    assert (
+        _normalize_identifier_for_semantic_scholar("https://example.org/paper", "url")
+        == "URL:https://example.org/paper"
+    )

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,9 +1,12 @@
+from typing import Any
+
 import pytest
 
 import paper_chaser_mcp
 import paper_chaser_mcp.__main__ as server_main
 import paper_chaser_mcp.cli as cli
 import paper_chaser_mcp.clients.serpapi.client as serpapi_client_module
+import paper_chaser_mcp.dispatch as dispatch_module
 from paper_chaser_mcp import server
 from paper_chaser_mcp.clients.serpapi import SerpApiScholarClient
 from paper_chaser_mcp.enrichment import PaperEnrichmentService
@@ -80,14 +83,14 @@ async def test_list_tools_returns_expected_public_contract() -> None:
         "focus",
         "latencyProfile",
     }
-    assert tool_map["follow_up_research"].inputSchema["required"] == ["searchSessionId", "question"]
+    assert tool_map["follow_up_research"].inputSchema["required"] == ["question"]
     assert set(tool_map["follow_up_research"].inputSchema["properties"]) == {
         "searchSessionId",
         "question",
     }
     assert tool_map["resolve_reference"].inputSchema["required"] == ["reference"]
     assert set(tool_map["resolve_reference"].inputSchema["properties"]) == {"reference"}
-    assert tool_map["inspect_source"].inputSchema["required"] == ["searchSessionId", "sourceId"]
+    assert tool_map["inspect_source"].inputSchema["required"] == ["sourceId"]
     assert set(tool_map["inspect_source"].inputSchema["properties"]) == {
         "searchSessionId",
         "sourceId",
@@ -1267,6 +1270,226 @@ async def test_provider_diagnostics_runtime_summary_warns_on_hidden_tools_and_tl
     assert any("tls verification is disabled" in warning.lower() for warning in warnings)
 
 
+def test_guided_normalize_follow_up_arguments_warns_on_ambiguous_session_and_empty_question() -> None:
+    isolated_registry = type(server.workspace_registry)()
+    isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-a",
+        query="Attention Is All You Need",
+        payload={"sources": [{"sourceId": "paper-a", "title": "Attention is All you Need"}]},
+    )
+    isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-b",
+        query="RAG",
+        payload={"sources": [{"sourceId": "paper-b", "title": "RAG Overview"}]},
+    )
+
+    normalized, meta = dispatch_module._guided_normalize_follow_up_arguments(
+        {"query": "   "},
+        workspace_registry=isolated_registry,
+    )
+
+    assert not normalized["searchSessionId"]
+    assert normalized["question"] == ""
+    assert any("multiple active sessions exist" in warning.lower() for warning in meta["warnings"])
+    assert any("question was empty" in warning.lower() for warning in meta["warnings"])
+
+
+def test_guided_normalize_inspect_arguments_repairs_invalid_session_and_missing_source() -> None:
+    isolated_registry = type(server.workspace_registry)()
+    isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-only-source",
+        query="Attention Is All You Need",
+        payload={"sources": [{"sourceId": "paper-a", "title": "Attention is All you Need"}]},
+    )
+
+    normalized, meta = dispatch_module._guided_normalize_inspect_arguments(
+        {"searchSessionId": "missing-session", "sourceId": "   "},
+        workspace_registry=isolated_registry,
+    )
+
+    assert normalized["searchSessionId"] == "ssn-only-source"
+    assert normalized["sourceId"] == "paper-a"
+    assert any("using active session" in warning.lower() for warning in meta["warnings"])
+    assert any("inferred the only inspectable source" in warning.lower() for warning in meta["warnings"])
+
+
+def test_guided_normalize_follow_up_arguments_repairs_invalid_session_to_unique_active_session() -> None:
+    isolated_registry = type(server.workspace_registry)()
+    isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-only-follow-up",
+        query="Attention Is All You Need",
+        payload={"sources": [{"sourceId": "paper-a", "title": "Attention is All you Need"}]},
+    )
+
+    normalized, meta = dispatch_module._guided_normalize_follow_up_arguments(
+        {"searchSessionId": "missing-session", "question": "Who wrote it?"},
+        workspace_registry=isolated_registry,
+    )
+
+    assert normalized["searchSessionId"] == "ssn-only-follow-up"
+    assert any("was unavailable; using active session" in warning.lower() for warning in meta["warnings"])
+
+
+def test_guided_normalize_inspect_arguments_infers_source_bearing_session_from_source_id() -> None:
+    isolated_registry = type(server.workspace_registry)()
+    isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-source-bearing",
+        query="Attention Is All You Need",
+        payload={"sources": [{"sourceId": "paper-a", "title": "Attention is All you Need"}]},
+    )
+    isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-other",
+        query="RAG",
+        payload={"sources": [{"sourceId": "paper-b", "title": "RAG Overview"}]},
+    )
+
+    normalized, meta = dispatch_module._guided_normalize_inspect_arguments(
+        {"sourceId": "paper-a"},
+        workspace_registry=isolated_registry,
+    )
+
+    assert normalized["searchSessionId"] == "ssn-source-bearing"
+    assert normalized["sourceId"] == "paper-a"
+    assert any("inferred source-bearing session" in warning.lower() for warning in meta["warnings"])
+
+
+def test_guided_source_metadata_answers_support_alias_and_multiple_fields() -> None:
+    sources: list[dict[str, Any]] = [
+        {
+            "sourceId": "paper-a",
+            "sourceAlias": "source-1",
+            "title": "Attention is All you Need",
+            "date": "2017",
+            "citation": {
+                "authors": ["Ashish Vaswani", "Noam Shazeer"],
+                "journalOrPublisher": "Neural Information Processing Systems",
+                "doi": "10.5555/3295222.3295349",
+                "year": "2017",
+            },
+        },
+        {
+            "sourceId": "paper-b",
+            "sourceAlias": "source-2",
+            "title": "RAG Overview",
+        },
+    ]
+
+    answers = dispatch_module._guided_source_metadata_answers(
+        "For sourceId source-1, who wrote it, what venue, DOI, year, and title are listed?",
+        sources,
+    )
+
+    joined = " ".join(answers)
+    assert "Ashish Vaswani" in joined
+    assert "Neural Information Processing Systems" in joined
+    assert "10.5555/3295222.3295349" in joined
+    assert "2017" in joined
+    assert "Attention is All you Need" in joined
+
+
+@pytest.mark.asyncio
+async def test_get_runtime_status_surfaces_configured_and_active_smart_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeBundle:
+        def selection_metadata(self) -> dict[str, object]:
+            return {
+                "configuredSmartProvider": "azure-openai",
+                "activeSmartProvider": "deterministic",
+                "plannerModel": "azure-openai:gpt-4o-mini",
+                "plannerModelSource": "deterministic",
+                "synthesisModel": "azure-openai:gpt-4o-mini",
+                "synthesisModelSource": "deterministic",
+            }
+
+    class _FakeRuntime:
+        _provider_bundle = _FakeBundle()
+
+        @staticmethod
+        def smart_provider_diagnostics() -> tuple[dict[str, bool], list[str]]:
+            return (
+                {
+                    "openai": False,
+                    "azure-openai": True,
+                    "anthropic": False,
+                    "nvidia": False,
+                    "google": False,
+                    "mistral": False,
+                    "huggingface": False,
+                },
+                ["azure-openai", "openai", "anthropic", "nvidia", "google", "mistral", "huggingface"],
+            )
+
+    monkeypatch.setattr(server, "agentic_runtime", _FakeRuntime())
+
+    payload = _payload(await server.call_tool("get_runtime_status", {}))
+
+    assert payload["runtimeSummary"]["configuredSmartProvider"] == "azure-openai"
+    assert payload["runtimeSummary"]["activeSmartProvider"] == "deterministic"
+    assert payload["providers"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_exact_identifier_reports_resolved_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    semantic = RecordingSemanticClient()
+    monkeypatch.setattr(server, "client", semantic)
+    monkeypatch.setattr(server, "enable_semantic_scholar", True)
+    monkeypatch.setattr(server, "enable_openalex", False)
+
+    payload = _payload(await server.call_tool("resolve_reference", {"reference": "10.1038/nrn3241"}))
+
+    assert payload["status"] == "resolved"
+    assert payload["resolutionType"] == "paper_identifier"
+    assert payload["resolutionConfidence"] == "high"
+    assert payload["bestMatch"]["paper"]["paperId"] == "DOI:10.1038/nrn3241"
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_arxiv_identifier_reports_resolved_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    semantic = RecordingSemanticClient()
+    monkeypatch.setattr(server, "client", semantic)
+    monkeypatch.setattr(server, "enable_semantic_scholar", True)
+    monkeypatch.setattr(server, "enable_openalex", False)
+
+    payload = _payload(await server.call_tool("resolve_reference", {"reference": "arXiv:1706.03762"}))
+
+    assert payload["status"] == "resolved"
+    assert payload["resolutionType"] == "paper_identifier"
+    assert payload["resolutionConfidence"] == "high"
+    assert payload["bestMatch"]["paper"]["paperId"] == "ARXIV:1706.03762"
+
+
+@pytest.mark.asyncio
+async def test_resolve_reference_semantic_scholar_url_reports_resolved_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    semantic = RecordingSemanticClient()
+    monkeypatch.setattr(server, "client", semantic)
+    monkeypatch.setattr(server, "enable_semantic_scholar", True)
+    monkeypatch.setattr(server, "enable_openalex", False)
+
+    payload = _payload(
+        await server.call_tool(
+            "resolve_reference",
+            {
+                "reference": (
+                    "https://www.semanticscholar.org/paper/Attention-Is-All-You-Need/"
+                    "204e3073870fae3d05bcbc2f6a8e263d9b72e776"
+                )
+            },
+        )
+    )
+
+    assert payload["status"] == "resolved"
+    assert payload["resolutionType"] == "paper_identifier"
+    assert payload["resolutionConfidence"] == "high"
+    assert payload["bestMatch"]["paper"]["paperId"] == "204e3073870fae3d05bcbc2f6a8e263d9b72e776"
+
+
 @pytest.mark.asyncio
 async def test_guided_wrappers_surface_unverified_leads(monkeypatch: pytest.MonkeyPatch) -> None:
     class _FakeRuntime:
@@ -1362,6 +1585,147 @@ async def test_guided_wrappers_surface_unverified_leads(monkeypatch: pytest.Monk
     assert follow_up["unverifiedLeads"][0]["sourceId"] == "lead-1"
     assert follow_up["unverifiedLeads"][0]["topicalRelevance"] == "off_topic"
     assert "failureSummary" in follow_up
+
+
+@pytest.mark.asyncio
+async def test_guided_research_blends_regulatory_and_literature_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeRuntime:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def search_papers_smart(self, **kwargs: object) -> dict[str, object]:
+            mode = str(kwargs.get("mode") or "auto")
+            self.calls.append(mode)
+            if mode == "regulatory":
+                return {
+                    "searchSessionId": "ssn-mixed-guided",
+                    "strategyMetadata": {"intent": "regulatory"},
+                    "structuredSources": [
+                        {
+                            "sourceId": "nleb-fr",
+                            "title": "Endangered Species Status for the Northern Long-Eared Bat",
+                            "provider": "federal_register",
+                            "sourceType": "primary_regulatory",
+                            "verificationStatus": "verified_metadata",
+                            "accessStatus": "full_text_verified",
+                            "topicalRelevance": "on_topic",
+                            "confidence": "high",
+                            "isPrimarySource": True,
+                        }
+                    ],
+                    "candidateLeads": [],
+                    "evidenceGaps": [],
+                    "coverageSummary": {
+                        "providersAttempted": ["ecos", "federal_register"],
+                        "providersSucceeded": ["federal_register"],
+                        "providersFailed": [],
+                        "providersZeroResults": ["ecos"],
+                        "likelyCompleteness": "partial",
+                        "searchMode": "regulatory_primary_source",
+                    },
+                    "failureSummary": None,
+                    "clarification": None,
+                    "regulatoryTimeline": {"events": [{"title": "NLEB rule"}]},
+                }
+            if mode == "review":
+                return {
+                    "searchSessionId": "ssn-mixed-guided",
+                    "strategyMetadata": {"intent": "review"},
+                    "structuredSources": [
+                        {
+                            "sourceId": "nleb-paper",
+                            "title": "Recent peer-reviewed review of northern long-eared bat conservation",
+                            "provider": "semantic_scholar",
+                            "sourceType": "scholarly_article",
+                            "verificationStatus": "verified_metadata",
+                            "accessStatus": "abstract_only",
+                            "topicalRelevance": "on_topic",
+                            "confidence": "medium",
+                            "isPrimarySource": False,
+                        }
+                    ],
+                    "candidateLeads": [],
+                    "evidenceGaps": ["Literature coverage may still be incomplete."],
+                    "coverageSummary": {
+                        "providersAttempted": ["semantic_scholar", "openalex"],
+                        "providersSucceeded": ["semantic_scholar"],
+                        "providersFailed": [],
+                        "providersZeroResults": ["openalex"],
+                        "likelyCompleteness": "partial",
+                        "searchMode": "smart_literature_review",
+                    },
+                    "failureSummary": None,
+                    "clarification": None,
+                }
+            raise AssertionError(f"Unexpected mode: {mode}")
+
+    runtime = _FakeRuntime()
+    monkeypatch.setattr(server, "agentic_runtime", runtime)
+
+    payload = _payload(
+        await server.call_tool(
+            "research",
+            {
+                "query": (
+                    "Summarize recent peer-reviewed literature and regulatory history for the northern "
+                    "long-eared bat under the ESA."
+                )
+            },
+        )
+    )
+
+    assert runtime.calls == ["regulatory", "review"]
+    assert payload["intent"] == "mixed"
+    assert payload["coverage"]["searchMode"] == "guided_hybrid_research"
+    assert len(payload["sources"]) == 2
+    assert any(source["sourceId"] == "nleb-fr" for source in payload["sources"])
+    assert any(source["sourceId"] == "nleb-paper" for source in payload["sources"])
+    assert any("inspect_source" in action for action in payload["nextActions"])
+    assert payload["regulatoryTimeline"]["events"][0]["title"] == "NLEB rule"
+
+
+@pytest.mark.asyncio
+async def test_guided_research_abstained_without_sources_omits_inspect_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeRuntime:
+        async def search_papers_smart(self, **kwargs: object) -> dict[str, object]:
+            del kwargs
+            return {
+                "searchSessionId": "ssn-no-sources",
+                "strategyMetadata": {"intent": "regulatory"},
+                "structuredSources": [],
+                "candidateLeads": [],
+                "evidenceGaps": [
+                    (
+                        "No primary-source regulatory timeline could be reconstructed from the currently "
+                        "enabled regulatory providers."
+                    )
+                ],
+                "coverageSummary": {
+                    "providersAttempted": ["ecos", "federal_register"],
+                    "providersSucceeded": [],
+                    "providersFailed": [],
+                    "providersZeroResults": ["ecos", "federal_register"],
+                    "likelyCompleteness": "unknown",
+                    "searchMode": "regulatory_primary_source",
+                },
+                "failureSummary": None,
+                "clarification": None,
+                "regulatoryTimeline": {"events": []},
+            }
+
+    monkeypatch.setattr(server, "agentic_runtime", _FakeRuntime())
+
+    payload = _payload(
+        await server.call_tool(
+            "research",
+            {"query": "Northern long-eared bat ESA listing status and Federal Register history"},
+        )
+    )
+
+    assert payload["status"] == "abstained"
+    assert payload["sources"] == []
+    assert not any("inspect_source" in action for action in payload["nextActions"])
+    assert any("follow_up_research" in action for action in payload["nextActions"])
 
 
 @pytest.mark.asyncio
@@ -1598,6 +1962,165 @@ async def test_follow_up_research_uses_saved_unverified_leads_for_source_overvie
 
 
 @pytest.mark.asyncio
+async def test_follow_up_research_infers_single_active_session_when_search_session_id_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeRuntime:
+        async def ask_result_set(self, **kwargs: object) -> dict[str, object]:
+            raise AssertionError(f"ask_result_set should not run for inferred session introspection: {kwargs!r}")
+
+    isolated_registry = type(server.workspace_registry)()
+    monkeypatch.setattr(server, "workspace_registry", isolated_registry)
+
+    record = isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-inferred-follow-up",
+        query="Tool-using agents for literature review",
+        payload={
+            "searchSessionId": "ssn-inferred-follow-up",
+            "structuredSources": [
+                {
+                    "sourceId": "paper-1",
+                    "title": "Tool-Using Agents for Literature Review",
+                    "provider": "semantic_scholar",
+                    "sourceType": "scholarly_article",
+                    "verificationStatus": "verified_metadata",
+                    "accessStatus": "abstract_only",
+                    "topicalRelevance": "on_topic",
+                    "confidence": "high",
+                    "canonicalUrl": "https://example.org/paper-1",
+                }
+            ],
+            "coverageSummary": {"searchMode": "smart_literature_review"},
+        },
+    )
+    assert record.search_session_id == "ssn-inferred-follow-up"
+    monkeypatch.setattr(server, "agentic_runtime", _FakeRuntime())
+
+    payload = _payload(
+        await server.call_tool(
+            "follow_up_research",
+            {
+                "question": "Which sources were found in this session?",
+            },
+        )
+    )
+
+    assert payload["searchSessionId"] == "ssn-inferred-follow-up"
+    assert payload["answerStatus"] == "answered"
+    assert payload["inputNormalization"]["warnings"]
+    assert "inferred active session" in payload["inputNormalization"]["warnings"][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_inspect_source_accepts_index_alias_without_search_session_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    isolated_registry = type(server.workspace_registry)()
+    monkeypatch.setattr(server, "workspace_registry", isolated_registry)
+
+    record = isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-inspect-alias",
+        query="California condor regulatory history",
+        payload={
+            "searchSessionId": "ssn-inspect-alias",
+            "structuredSources": [
+                {
+                    "sourceId": "condor-fr",
+                    "title": "Critical Habitat Revision for California Condor",
+                    "provider": "federal_register",
+                    "sourceType": "primary_regulatory",
+                    "verificationStatus": "verified_metadata",
+                    "accessStatus": "full_text_verified",
+                    "topicalRelevance": "on_topic",
+                    "confidence": "high",
+                    "canonicalUrl": "https://example.org/condor-fr",
+                }
+            ],
+        },
+    )
+    assert record.search_session_id == "ssn-inspect-alias"
+
+    payload = _payload(
+        await server.call_tool(
+            "inspect_source",
+            {
+                "sourceId": "source-1",
+            },
+        )
+    )
+
+    assert payload["searchSessionId"] == "ssn-inspect-alias"
+    assert payload["source"]["sourceId"] == "condor-fr"
+    assert payload["sourceResolution"]["matchType"] == "index_alias"
+
+
+@pytest.mark.asyncio
+async def test_follow_up_research_requires_explicit_session_when_multiple_are_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    isolated_registry = type(server.workspace_registry)()
+    monkeypatch.setattr(server, "workspace_registry", isolated_registry)
+
+    isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-follow-up-a",
+        query="Attention Is All You Need",
+        payload={"sources": [{"sourceId": "paper-a", "title": "Attention is All you Need"}]},
+    )
+    isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-follow-up-b",
+        query="Retrieval-Augmented Generation",
+        payload={"sources": [{"sourceId": "paper-b", "title": "RAG Overview"}]},
+    )
+
+    payload = _payload(
+        await server.call_tool(
+            "follow_up_research",
+            {
+                "question": "What venue is listed for this paper?",
+            },
+        )
+    )
+
+    assert payload["answerStatus"] == "insufficient_evidence"
+    assert payload["searchSessionId"] is None
+    assert "unique saved search session" in payload["evidenceGaps"][0].lower()
+    assert "multiple active sessions exist" in payload["inputNormalization"]["warnings"][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_inspect_source_requires_explicit_session_when_multiple_are_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    isolated_registry = type(server.workspace_registry)()
+    monkeypatch.setattr(server, "workspace_registry", isolated_registry)
+
+    isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-inspect-a",
+        query="Attention Is All You Need",
+        payload={"sources": [{"sourceId": "paper-a", "title": "Attention is All you Need"}]},
+    )
+    isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-inspect-b",
+        query="Retrieval-Augmented Generation",
+        payload={"sources": [{"sourceId": "paper-b", "title": "RAG Overview"}]},
+    )
+
+    with pytest.raises(ValueError, match="could not infer a unique searchSessionId"):
+        await server.call_tool(
+            "inspect_source",
+            {
+                "sourceId": "source-1",
+            },
+        )
+
+
+@pytest.mark.asyncio
 async def test_follow_up_research_answers_from_saved_session_metadata_when_partial_session_has_verified_findings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1706,6 +2229,147 @@ async def test_follow_up_research_answers_from_saved_session_metadata_when_parti
     ) in payload["answer"]
     assert payload["failureSummary"]["primaryPathFailureReason"] == "core"
     assert payload["verifiedFindings"][0]["claim"] == "Ragas: Automated Evaluation of Retrieval Augmented Generation"
+
+
+@pytest.mark.asyncio
+async def test_follow_up_research_answers_authors_and_venue_from_saved_source_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeRuntime:
+        async def ask_result_set(self, **kwargs: object) -> dict[str, object]:
+            raise AssertionError(f"ask_result_set should not run for source metadata introspection: {kwargs!r}")
+
+    isolated_registry = type(server.workspace_registry)()
+    monkeypatch.setattr(server, "workspace_registry", isolated_registry)
+    monkeypatch.setattr(server, "agentic_runtime", _FakeRuntime())
+
+    isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-follow-up-source-metadata",
+        query="Attention Is All You Need",
+        payload={
+            "searchSessionId": "ssn-follow-up-source-metadata",
+            "sources": [
+                {
+                    "sourceId": "attention-paper",
+                    "title": "Attention is All you Need",
+                    "provider": "semantic_scholar",
+                    "sourceType": "scholarly_article",
+                    "verificationStatus": "verified_metadata",
+                    "accessStatus": "access_unverified",
+                    "topicalRelevance": "on_topic",
+                    "confidence": "high",
+                    "citation": {
+                        "authors": ["Ashish Vaswani", "Noam Shazeer", "Niki Parmar"],
+                        "year": "2017",
+                        "title": "Attention is All you Need",
+                        "journalOrPublisher": "Neural Information Processing Systems",
+                        "doi": None,
+                        "url": "https://www.semanticscholar.org/paper/204e3073870fae3d05bcbc2f6a8e263d9b72e776",
+                        "sourceType": "scholarly_article",
+                        "confidence": "medium",
+                    },
+                    "date": "2017-06-12",
+                }
+            ],
+        },
+    )
+
+    payload = _payload(
+        await server.call_tool(
+            "follow_up_research",
+            {
+                "searchSessionId": "ssn-follow-up-source-metadata",
+                "question": "Who are the authors and what venue is listed for this paper?",
+            },
+        )
+    )
+
+    assert payload["answerStatus"] == "answered"
+    assert "Ashish Vaswani" in payload["answer"]
+    assert "Neural Information Processing Systems" in payload["answer"]
+
+
+@pytest.mark.asyncio
+async def test_follow_up_research_recovers_when_agentic_answer_is_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeRuntime:
+        async def ask_result_set(self, **kwargs: object) -> dict[str, object]:
+            return {
+                "answerStatus": "answered",
+                "answer": " : ",
+                "structuredSources": [
+                    {
+                        "sourceId": "attention-paper",
+                        "title": "Attention is All you Need",
+                        "provider": "semantic_scholar",
+                        "sourceType": "scholarly_article",
+                        "verificationStatus": "verified_metadata",
+                        "accessStatus": "access_unverified",
+                        "topicalRelevance": "on_topic",
+                        "confidence": "high",
+                        "citation": {
+                            "authors": ["Ashish Vaswani", "Noam Shazeer"],
+                            "year": "2017",
+                            "title": "Attention is All you Need",
+                            "journalOrPublisher": "Neural Information Processing Systems",
+                        },
+                    }
+                ],
+                "candidateLeads": [],
+                "evidence": [],
+                "unsupportedAsks": [],
+                "followUpQuestions": [],
+                "evidenceGaps": [],
+                "coverageSummary": None,
+                "failureSummary": None,
+            }
+
+    isolated_registry = type(server.workspace_registry)()
+    monkeypatch.setattr(server, "workspace_registry", isolated_registry)
+    monkeypatch.setattr(server, "agentic_runtime", _FakeRuntime())
+
+    isolated_registry.save_result_set(
+        source_tool="search_papers_smart",
+        search_session_id="ssn-follow-up-blank-agentic-answer",
+        query="Attention Is All You Need",
+        payload={
+            "searchSessionId": "ssn-follow-up-blank-agentic-answer",
+            "sources": [
+                {
+                    "sourceId": "attention-paper",
+                    "title": "Attention is All you Need",
+                    "provider": "semantic_scholar",
+                    "sourceType": "scholarly_article",
+                    "verificationStatus": "verified_metadata",
+                    "accessStatus": "access_unverified",
+                    "topicalRelevance": "on_topic",
+                    "confidence": "high",
+                    "citation": {
+                        "authors": ["Ashish Vaswani", "Noam Shazeer"],
+                        "year": "2017",
+                        "title": "Attention is All you Need",
+                        "journalOrPublisher": "Neural Information Processing Systems",
+                    },
+                }
+            ],
+        },
+    )
+
+    payload = _payload(
+        await server.call_tool(
+            "follow_up_research",
+            {
+                "searchSessionId": "ssn-follow-up-blank-agentic-answer",
+                "question": "What venue is listed for this paper?",
+            },
+        )
+    )
+
+    assert payload["answerStatus"] == "answered"
+    assert payload["answer"] != " : "
+    assert "Neural Information Processing Systems" in payload["answer"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_semantic_scholar_client.py
+++ b/tests/test_semantic_scholar_client.py
@@ -1798,6 +1798,20 @@ async def test_search_snippets_degrades_provider_400_to_empty_payload(
     assert "search_papers_match/search_papers" in result["message"]
 
 
+def test_normalize_paper_id_handles_doi_and_semantic_scholar_urls() -> None:
+    sc = server.SemanticScholarClient()
+
+    assert sc._normalize_paper_id("10.1038/nrn3241") == "DOI:10.1038/nrn3241"
+    assert sc._normalize_paper_id("https://doi.org/10.1038/nrn3241") == "DOI:10.1038/nrn3241"
+    assert (
+        sc._normalize_paper_id(
+            "https://www.semanticscholar.org/paper/Attention-Is-All-You-Need/204e3073870fae3d05bcbc2f6a8e263d9b72e776"
+        )
+        == "204e3073870fae3d05bcbc2f6a8e263d9b72e776"
+    )
+    assert sc._normalize_paper_id("https://example.com/paper/123") == "URL:https://example.com/paper/123"
+
+
 @pytest.mark.asyncio
 async def test_search_snippets_degrades_provider_429_without_backoff_retry(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_smart_tools.py
+++ b/tests/test_smart_tools.py
@@ -425,8 +425,15 @@ async def test_search_papers_smart_routes_regulatory_queries_to_primary_sources(
 
     assert payload["results"] == []
     assert payload["strategyMetadata"]["intent"] == "regulatory"
+    assert payload["strategyMetadata"]["anchorType"] == "cfr_citation"
+    assert payload["strategyMetadata"]["anchorStrength"] == "high"
+    assert payload["strategyMetadata"]["anchoredSubject"]
+    assert payload["strategyMetadata"]["bestNextInternalAction"] == "inspect_source"
     assert payload["structuredSources"]
+    assert any(source.get("sourceAlias") for source in payload["structuredSources"])
     assert payload["verifiedFindings"]
+    assert payload["resultStatus"] == "succeeded"
+    assert payload["hasInspectableSources"] is True
     assert payload["coverageSummary"]["searchMode"] == "regulatory_primary_source"
     assert payload["coverageSummary"]["primaryDocumentCoverage"]["currentTextRequested"] is True
     assert payload["coverageSummary"]["primaryDocumentCoverage"]["currentTextSatisfied"] is True
@@ -667,6 +674,138 @@ async def test_search_papers_smart_regulatory_marks_history_only_when_current_cf
     assert primary_document["historyOnly"] is True
     assert any("Current codified CFR text was not verified from GovInfo" in gap for gap in payload["evidenceGaps"])
     assert payload["failureSummary"]["outcome"] == "fallback_success"
+
+
+@pytest.mark.asyncio
+async def test_search_papers_smart_regulatory_uses_govinfo_federal_register_fallback() -> None:
+    semantic = RecordingSemanticClient()
+    openalex = RecordingOpenAlexClient()
+
+    class EmptyEcosClient:
+        async def search_species(self, *, query: str, limit: int = 10, match_mode: str = "auto") -> dict[str, Any]:
+            del query, limit, match_mode
+            return {"data": []}
+
+    class EmptyFederalRegisterClient:
+        async def search_documents(self, *, query: str, limit: int = 10, **kwargs: Any) -> dict[str, Any]:
+            del query, limit, kwargs
+            return {"total": 0, "data": []}
+
+    class GovInfoSearchClient:
+        async def search_federal_register_documents(self, *, query: str, limit: int = 10) -> dict[str, Any]:
+            del limit
+            assert "northern long-eared bat" in query.lower()
+            return {
+                "total": 1,
+                "data": [
+                    {
+                        "title": "Endangered Species Status for the Northern Long-Eared Bat",
+                        "documentNumber": "2022-25998",
+                        "citation": "87 FR 73488",
+                        "publicationDate": "2022-11-30",
+                        "sourceUrl": "https://www.govinfo.gov/app/details/FR-2022-11-30/2022-25998",
+                        "verificationStatus": "verified_metadata",
+                        "note": "GovInfo Federal Register primary-source recovery hit.",
+                    }
+                ],
+            }
+
+    _, runtime = _deterministic_runtime(
+        semantic=semantic,
+        openalex=openalex,
+        ecos=EmptyEcosClient(),
+        federal_register=EmptyFederalRegisterClient(),
+        govinfo=GovInfoSearchClient(),
+        enable_ecos=True,
+        enable_federal_register=True,
+        enable_govinfo_cfr=True,
+    )
+
+    payload = await runtime.search_papers_smart(
+        query="Northern long-eared bat ESA listing status and final rule history",
+        limit=5,
+    )
+
+    assert payload["strategyMetadata"]["intent"] == "regulatory"
+    assert payload["strategyMetadata"]["intentSource"] == "heuristic_override"
+    assert payload["strategyMetadata"]["intentConfidence"] == "medium"
+    assert payload["strategyMetadata"]["anchorType"] == "regulatory_subject_terms"
+    assert payload["strategyMetadata"]["recoveryAttempted"] is False
+    assert "govinfo" in payload["coverageSummary"]["providersAttempted"]
+    assert "govinfo" in payload["coverageSummary"]["providersSucceeded"]
+    assert any(source["provider"] == "govinfo" for source in payload["structuredSources"])
+    assert any(source.get("sourceAlias") for source in payload["structuredSources"])
+    assert payload["verifiedFindings"]
+
+
+@pytest.mark.asyncio
+async def test_search_papers_smart_recovers_known_item_when_forced_regulatory_mode_returns_nothing() -> None:
+    semantic = RecordingSemanticClient()
+    openalex = RecordingOpenAlexClient()
+    exact_title = (
+        "Ecosystem experiment reveals benefits of natural and simulated beaver dams to a threatened "
+        "population of steelhead (Oncorhynchus mykiss)"
+    )
+
+    async def semantic_match(**kwargs: Any) -> dict[str, Any]:
+        semantic.calls.append(("search_papers_match", dict(kwargs)))
+        return {
+            "paperId": "1539acae748ff423bf4ebd2da0d95933e94f59ee",
+            "title": exact_title,
+            "year": 2016,
+            "authors": [{"name": "N. Bouwes"}],
+            "venue": "Scientific Reports",
+            "source": "semantic_scholar",
+            "matchStrategy": "semantic_title_match",
+        }
+
+    semantic.search_papers_match = semantic_match  # type: ignore[method-assign]
+
+    class EmptyEcosClient:
+        async def search_species(self, *, query: str, limit: int = 10, match_mode: str = "auto") -> dict[str, Any]:
+            del query, limit, match_mode
+            return {"data": []}
+
+    class EmptyFederalRegisterClient:
+        async def search_documents(self, *, query: str, limit: int = 10, **kwargs: Any) -> dict[str, Any]:
+            del query, limit, kwargs
+            return {"total": 0, "data": []}
+
+    class EmptyGovInfoClient:
+        async def search_federal_register_documents(self, *, query: str, limit: int = 10) -> dict[str, Any]:
+            del query, limit
+            return {"total": 0, "data": []}
+
+    _, runtime = _deterministic_runtime(
+        semantic=semantic,
+        openalex=openalex,
+        ecos=EmptyEcosClient(),
+        federal_register=EmptyFederalRegisterClient(),
+        govinfo=EmptyGovInfoClient(),
+        enable_ecos=True,
+        enable_federal_register=True,
+        enable_govinfo_cfr=True,
+    )
+
+    payload = await runtime.search_papers_smart(
+        query=exact_title,
+        limit=5,
+        mode="regulatory",
+    )
+
+    assert payload["strategyMetadata"]["intent"] == "known_item"
+    assert payload["strategyMetadata"]["intentSource"] == "fallback_recovery"
+    assert payload["strategyMetadata"]["recoveryAttempted"] is True
+    assert payload["strategyMetadata"]["recoveryPath"] == ["regulatory", "known_item"]
+    assert payload["strategyMetadata"]["recoveryReason"] == "Regulatory retrieval returned no on-topic sources."
+    assert payload["strategyMetadata"]["bestNextInternalAction"] == "get_paper_details"
+    assert payload["results"][0]["paper"]["title"] == exact_title
+    assert payload["resultStatus"] == "succeeded"
+    assert payload["hasInspectableSources"] is True
+    assert any(
+        "retried with semantic known-item recovery" in warning.lower()
+        for warning in payload["strategyMetadata"]["driftWarnings"]
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR tightens the guided research contract so low-context clients get safer, more recoverable behavior when inputs are imperfect. It hardens guided argument normalization and session/source recovery, improves result-state and recovery metadata, adds GovInfo-backed regulatory recovery, and raises identifier-based citation resolution confidence while updating docs and tests to match.

## Motivation

Current guided flows still assume clients send clean `searchSessionId`, `sourceId`, and citation inputs. In practice, agents send wrapper text, alternate field names, stale session IDs, alias-like source references, or exact identifiers that should resolve without fuzzy search. The goal here is to recover internally when the server can do so safely, and to return machine-readable explanations when it cannot.

## What Changed

- Guided dispatch now normalizes `research`, `follow_up_research`, and `inspect_source` inputs before validation, including whitespace cleanup, wrapper-phrase stripping, and safe citation-surface canonicalization.
- `follow_up_research` and `inspect_source` can repair alternate or missing session and source fields only when one compatible active session is uniquely identifiable; ambiguous cases now return explicit `insufficient_evidence` guidance instead of guessing.
- Guided responses now expose additional machine-readable contract fields such as `resultState`, `inputNormalization`, and `machineFailure` so clients can inspect routing, recovery, and failure semantics.
- `inspect_source` now accepts multiple source-resolution paths: exact IDs, case-folded IDs, canonical URL or citation matches, session-local aliases like `source-1`, and unique partial-title matches.
- The smart planner and runtime path now records richer recovery metadata including intent candidates, routing confidence, recovery path and reason, anchor strength, normalization warnings, and repaired inputs.
- Regulatory recovery is more resilient: when the main regulatory route underperforms, the system can fall back through broader recovery paths and can use GovInfo Federal Register search to recover primary-source hits and timelines.
- Citation resolution now normalizes bare DOIs, DOI URLs, arXiv identifiers, and URL-shaped identifiers more consistently for Semantic Scholar and OpenAlex, improving high-confidence identifier matches before fuzzy repair.
- Docs now explicitly describe guided robustness expectations and recovery semantics, and focused regressions cover normalization, alias resolution, ambiguity handling, regulatory fallback, and identifier normalization.

## Key Files

- `paper_chaser_mcp/dispatch.py`: guided normalization, session and source recovery, result-state fields, follow-up and inspect behavior, and regulatory handling.
- `paper_chaser_mcp/agentic/planner.py`, `paper_chaser_mcp/agentic/models.py`, `paper_chaser_mcp/agentic/workspace.py`: richer recovery metadata and session-registry helpers.
- `paper_chaser_mcp/citation_repair.py`, `paper_chaser_mcp/clients/govinfo/client.py`, `paper_chaser_mcp/clients/semantic_scholar/client.py`: identifier normalization and GovInfo fallback support.
- `docs/guided-smart-robustness.md` plus README, golden paths, migration note, and handoff updates.
- `tests/test_dispatch.py`, `tests/test_citation_repair.py`, `tests/test_smart_tools.py`, `tests/test_semantic_scholar_client.py`: focused regression coverage.

## Validation

Ran focused regressions for the touched areas:

```bash
python -m pytest tests/test_dispatch.py tests/test_citation_repair.py tests/test_smart_tools.py tests/test_semantic_scholar_client.py -q
```

Result: `195 passed in 7.65s`

## Risks

- Guided recovery is intentionally stricter than before, but any future expansion of inference heuristics could over-recover and bind to the wrong session or source if uniqueness checks weaken.
- The additive metadata expands the public contract surface, so docs, prompts, and tests need to stay synchronized when names or semantics change.
- Regulatory fallback and mixed-query routing still rely on heuristics that may need tuning with real-world prompts.
- Identifier normalization improves exact-match recovery, but provider-specific edge cases can still surface around unusual DOI or URL forms.

## Reviewer Guide

1. Start with `paper_chaser_mcp/dispatch.py` for the guided contract changes.
2. Review `paper_chaser_mcp/agentic/planner.py`, `paper_chaser_mcp/agentic/models.py`, and `paper_chaser_mcp/agentic/workspace.py` for recovery and session metadata.
3. Review `paper_chaser_mcp/citation_repair.py` and `paper_chaser_mcp/clients/govinfo/client.py` for exact-identifier and regulatory fallback behavior.
4. Finish with the docs and focused tests to confirm the public story matches the implementation.

## Next Steps

- Run the full repo validation stack before merge if we want release-grade confidence instead of focused regression confidence.
- Collect real query examples to tune ambiguous-session warnings and mixed regulatory and literature routing.
- Decide whether any of the new machine-readable recovery fields should be elevated into more formal contract docs or client examples.