### PR TITLE
Make mypy behavior consistent between local pre-commit and CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -83,8 +83,6 @@ jobs:
           git diff --exit-code -- .github/workflows/test-paper-chaser.lock.yml
 
       - name: Run pre-commit
-        env:
-          SKIP: mypy
         run: pre-commit run --all-files
 
       - name: Run tests
@@ -122,9 +120,6 @@ jobs:
           # Temporary ignore: pip-audit flags CVE-2026-4539 for transitive
           # Pygments releases, but no fixed upstream version is published yet.
           python -m pip_audit . --progress-spinner off --ignore-vuln CVE-2026-4539
-
-      - name: Run mypy
-        run: python -m mypy --config-file pyproject.toml
 
       - name: Run Bandit
         run: python -m bandit -c pyproject.toml -r paper_chaser_mcp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
         name: mypy
         entry: python scripts/run_mypy_precommit.py
         language: system
+        pass_filenames: false
         files: ^(paper_chaser_mcp/.*\.py|tests/.*\.py|pyproject\.toml)$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/scripts/run_mypy_precommit.py
+++ b/scripts/run_mypy_precommit.py
@@ -1,74 +1,38 @@
-"""Run mypy for pre-commit, scoped to changed Python files when possible."""
+"""Run mypy for pre-commit with a single retry on INTERNAL ERROR.
+
+The script always invokes ``python -m mypy --config-file pyproject.toml`` using
+the interpreter that is executing the hook (``sys.executable``). Project scope
+is determined entirely by ``[tool.mypy] files`` in ``pyproject.toml``, so the
+hook and a direct ``python -m mypy`` invocation cover the same code and the
+behaviour is identical locally and in CI.
+
+Incremental mode is used by default (mypy's ``.mypy_cache/``) so local
+pre-commit runs stay fast. If mypy hits an ``INTERNAL ERROR`` (a known failure
+mode when the incremental cache is stale or corrupted), the script retries
+once with ``--no-incremental`` and surfaces the final exit code unchanged.
+There is no CI-specific branch; failures always propagate.
+"""
 
 from __future__ import annotations
 
-import os
 import subprocess  # nosec B404
 import sys
 from pathlib import Path
 from typing import Sequence
 
-MYPY_BASE_COMMAND = ["-m", "mypy", "--config-file", "pyproject.toml"]
+MYPY_BASE_COMMAND: list[str] = [
+    sys.executable,
+    "-m",
+    "mypy",
+    "--config-file",
+    "pyproject.toml",
+]
 MYPY_INTERNAL_ERROR_MARKER = "error: INTERNAL ERROR"
 NO_INCREMENTAL_FLAG = "--no-incremental"
 
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
-
-
-def _repo_venv_python() -> Path:
-    root = _repo_root()
-    candidates = (
-        root / ".venv" / "Scripts" / "python.exe",
-        root / ".venv" / "bin" / "python",
-    )
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
-    return Path(sys.executable)
-
-
-def _requires_full_run(filenames: Sequence[str]) -> bool:
-    return any(Path(filename).name == "pyproject.toml" for filename in filenames)
-
-
-def _python_targets(filenames: Sequence[str]) -> list[str]:
-    return [filename for filename in filenames if filename.endswith(".py")]
-
-
-def _split_precommit_args(argv: Sequence[str]) -> tuple[list[str], list[str]]:
-    passthrough_flags: list[str] = []
-    filenames: list[str] = []
-    for arg in argv:
-        if arg == NO_INCREMENTAL_FLAG:
-            passthrough_flags.append(arg)
-            continue
-        filenames.append(arg)
-    return passthrough_flags, filenames
-
-
-def _base_command(passthrough_flags: Sequence[str]) -> list[str]:
-    return [str(_repo_venv_python()), *MYPY_BASE_COMMAND, *passthrough_flags]
-
-
-def _ensure_no_incremental(command: Sequence[str]) -> list[str]:
-    if NO_INCREMENTAL_FLAG in command:
-        return list(command)
-    return [*command, NO_INCREMENTAL_FLAG]
-
-
-def build_mypy_command(argv: Sequence[str]) -> list[str]:
-    passthrough_flags, filenames = _split_precommit_args(argv)
-    command = _base_command(passthrough_flags)
-    if _requires_full_run(filenames):
-        return command
-
-    python_targets = _python_targets(filenames)
-    if not python_targets:
-        return command
-
-    return [*command, *python_targets]
 
 
 def _run_mypy(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
@@ -81,53 +45,31 @@ def _run_mypy(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _emit_completed_output(completed: subprocess.CompletedProcess[str]) -> None:
+def _is_internal_error(completed: subprocess.CompletedProcess[str]) -> bool:
+    combined = f"{completed.stdout or ''}\n{completed.stderr or ''}"
+    return MYPY_INTERNAL_ERROR_MARKER in combined
+
+
+def _emit(completed: subprocess.CompletedProcess[str]) -> None:
     if completed.stdout:
         print(completed.stdout, end="")
     if completed.stderr:
         print(completed.stderr, end="", file=sys.stderr)
 
 
-def _is_internal_error_retryable(
-    initial_command: Sequence[str],
-    full_command: Sequence[str],
-    completed: subprocess.CompletedProcess[str],
-) -> bool:
-    if list(initial_command) == list(full_command):
-        return False
-    if completed.returncode == 0:
-        return False
-
-    return _is_internal_error(completed)
-
-
-def _is_internal_error(completed: subprocess.CompletedProcess[str]) -> bool:
-    combined_output = f"{completed.stdout or ''}\n{completed.stderr or ''}"
-    return MYPY_INTERNAL_ERROR_MARKER in combined_output
-
-
 def main(argv: Sequence[str] | None = None) -> int:
-    args = list(sys.argv[1:] if argv is None else argv)
-    passthrough_flags, _filenames = _split_precommit_args(args)
-    scoped_command = build_mypy_command(args)
-    full_command = _base_command(passthrough_flags)
+    extra_args = list(sys.argv[1:] if argv is None else argv)
+    command: list[str] = [*MYPY_BASE_COMMAND, *extra_args]
+    completed = _run_mypy(command)
 
-    completed = _run_mypy(scoped_command)
-    if _is_internal_error_retryable(scoped_command, full_command, completed):
+    if completed.returncode != 0 and _is_internal_error(completed) and NO_INCREMENTAL_FLAG not in command:
         print(
-            "Scoped mypy run hit an internal error; retrying full project check without incremental state.",
+            "mypy hit an INTERNAL ERROR; retrying once with --no-incremental.",
             file=sys.stderr,
         )
-        completed = _run_mypy(_ensure_no_incremental(full_command))
-        if os.environ.get("GITHUB_ACTIONS", "").lower() == "true" and completed.returncode != 0:
-            print(
-                f"Full-project mypy retry exited with code {completed.returncode} in GitHub Actions; "
-                "deferring to the dedicated workflow mypy step.",
-                file=sys.stderr,
-            )
-            return 0
+        completed = _run_mypy([*command, NO_INCREMENTAL_FLAG])
 
-    _emit_completed_output(completed)
+    _emit(completed)
     return completed.returncode
 
 

--- a/tests/test_run_mypy_precommit.py
+++ b/tests/test_run_mypy_precommit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 from subprocess import CompletedProcess
 
@@ -16,151 +17,147 @@ def _load_module():
 
 
 def _expected_base_command() -> list[str]:
-    return [
-        str(Path(".venv/Scripts/python.exe")),
-        "-m",
-        "mypy",
-        "--config-file",
-        "pyproject.toml",
-    ]
+    return [sys.executable, "-m", "mypy", "--config-file", "pyproject.toml"]
 
 
-def test_build_mypy_command_limits_pre_commit_run_to_changed_python_files(monkeypatch) -> None:
+def test_base_command_uses_running_interpreter() -> None:
     module = _load_module()
-    monkeypatch.setattr(module, "_repo_venv_python", lambda: Path(".venv/Scripts/python.exe"))
 
-    command = module.build_mypy_command(
-        [
-            "paper_chaser_mcp/server.py",
-            "tests/test_dispatch.py",
-        ]
-    )
-
-    assert command == [
-        *_expected_base_command(),
-        "paper_chaser_mcp/server.py",
-        "tests/test_dispatch.py",
-    ]
+    assert module.MYPY_BASE_COMMAND == _expected_base_command()
 
 
-def test_build_mypy_command_runs_full_check_when_pyproject_changes(monkeypatch) -> None:
+def test_main_runs_project_scoped_mypy_by_default(monkeypatch, capsys) -> None:
     module = _load_module()
-    monkeypatch.setattr(module, "_repo_venv_python", lambda: Path(".venv/Scripts/python.exe"))
 
-    command = module.build_mypy_command(["pyproject.toml"])
+    calls: list[list[str]] = []
 
-    assert command == _expected_base_command()
+    def _fake_run(command):
+        calls.append(list(command))
+        return CompletedProcess(list(command), 0, stdout="Success: no issues found\n", stderr="")
+
+    monkeypatch.setattr(module, "_run_mypy", _fake_run)
+
+    exit_code = module.main([])
+
+    assert exit_code == 0
+    assert calls == [_expected_base_command()]
+    assert "Success: no issues found" in capsys.readouterr().out
 
 
-def test_build_mypy_command_ignores_non_python_targets(monkeypatch) -> None:
+def test_main_retries_with_no_incremental_on_internal_error(monkeypatch, capsys) -> None:
     module = _load_module()
-    monkeypatch.setattr(module, "_repo_venv_python", lambda: Path(".venv/Scripts/python.exe"))
 
-    command = module.build_mypy_command(["README.md"])
+    calls: list[list[str]] = []
 
-    assert command == _expected_base_command()
-
-
-def test_build_mypy_command_is_incremental_by_default(monkeypatch) -> None:
-    module = _load_module()
-    monkeypatch.setattr(module, "_repo_venv_python", lambda: Path(".venv/Scripts/python.exe"))
-
-    command = module.build_mypy_command(["paper_chaser_mcp/server.py"])
-
-    assert module.NO_INCREMENTAL_FLAG not in command
-
-
-def test_build_mypy_command_passes_through_no_incremental(monkeypatch) -> None:
-    module = _load_module()
-    monkeypatch.setattr(module, "_repo_venv_python", lambda: Path(".venv/Scripts/python.exe"))
-
-    command = module.build_mypy_command([module.NO_INCREMENTAL_FLAG, "paper_chaser_mcp/server.py"])
-
-    assert command == [
-        *_expected_base_command(),
-        module.NO_INCREMENTAL_FLAG,
-        "paper_chaser_mcp/server.py",
-    ]
-
-
-def test_main_retries_full_run_after_retryable_internal_error(monkeypatch, capsys) -> None:
-    module = _load_module()
-    monkeypatch.setattr(module, "_repo_venv_python", lambda: Path(".venv/Scripts/python.exe"))
-
-    commands: list[list[str]] = []
-
-    def _fake_run(command: list[str]):
-        commands.append(command)
-        if len(commands) == 1:
+    def _fake_run(command):
+        calls.append(list(command))
+        if len(calls) == 1:
             return CompletedProcess(
-                command,
+                list(command),
                 2,
                 stdout="",
                 stderr=f"{module.MYPY_INTERNAL_ERROR_MARKER}\n",
             )
-        return CompletedProcess(command, 0, stdout="Success: no issues found\n", stderr="")
+        return CompletedProcess(list(command), 0, stdout="Success: no issues found\n", stderr="")
 
     monkeypatch.setattr(module, "_run_mypy", _fake_run)
 
-    exit_code = module.main(["paper_chaser_mcp/server.py"])
+    exit_code = module.main([])
 
     assert exit_code == 0
-    assert commands == [
-        [*_expected_base_command(), "paper_chaser_mcp/server.py"],
+    assert calls == [
+        _expected_base_command(),
         [*_expected_base_command(), module.NO_INCREMENTAL_FLAG],
     ]
     captured = capsys.readouterr()
-    assert "retrying full project check without incremental state" in captured.err
+    assert "retrying once with --no-incremental" in captured.err
     assert "Success: no issues found" in captured.out
 
 
-def test_main_does_not_retry_full_run_for_non_retryable_failure(monkeypatch, capsys) -> None:
+def test_main_does_not_retry_on_regular_type_errors(monkeypatch, capsys) -> None:
     module = _load_module()
-    monkeypatch.setattr(module, "_repo_venv_python", lambda: Path(".venv/Scripts/python.exe"))
 
-    commands: list[list[str]] = []
+    calls: list[list[str]] = []
 
-    def _fake_run(command: list[str]):
-        commands.append(command)
-        return CompletedProcess(command, 1, stdout="", stderr="paper_chaser_mcp/server.py:1: error: boom\n")
+    def _fake_run(command):
+        calls.append(list(command))
+        return CompletedProcess(
+            list(command),
+            1,
+            stdout="",
+            stderr="paper_chaser_mcp/server.py:1: error: boom\n",
+        )
 
     monkeypatch.setattr(module, "_run_mypy", _fake_run)
 
-    exit_code = module.main(["paper_chaser_mcp/server.py"])
+    exit_code = module.main([])
 
     assert exit_code == 1
-    assert commands == [[*_expected_base_command(), "paper_chaser_mcp/server.py"]]
+    assert calls == [_expected_base_command()]
     captured = capsys.readouterr()
-    assert "retrying full project check" not in captured.err
+    assert "retrying" not in captured.err
     assert "error: boom" in captured.err
 
 
-def test_main_defers_persistent_internal_errors_to_ci_mypy_step(monkeypatch, capsys) -> None:
+def test_main_surfaces_persistent_internal_errors(monkeypatch) -> None:
     module = _load_module()
-    monkeypatch.setattr(module, "_repo_venv_python", lambda: Path(".venv/Scripts/python.exe"))
-    monkeypatch.setenv("GITHUB_ACTIONS", "true")
 
-    commands: list[list[str]] = []
+    calls: list[list[str]] = []
 
-    def _fake_run(command: list[str]):
-        commands.append(command)
+    def _fake_run(command):
+        calls.append(list(command))
         return CompletedProcess(
-            command,
-            245,
+            list(command),
+            2,
             stdout="",
             stderr=f"{module.MYPY_INTERNAL_ERROR_MARKER}\n",
         )
 
     monkeypatch.setattr(module, "_run_mypy", _fake_run)
 
-    exit_code = module.main(["paper_chaser_mcp/server.py"])
+    exit_code = module.main([])
 
-    assert exit_code == 0
-    assert commands == [
-        [*_expected_base_command(), "paper_chaser_mcp/server.py"],
+    assert exit_code == 2
+    assert calls == [
+        _expected_base_command(),
         [*_expected_base_command(), module.NO_INCREMENTAL_FLAG],
     ]
-    captured = capsys.readouterr()
-    assert "retrying full project check without incremental state" in captured.err
-    assert "Full-project mypy retry exited with code 245 in GitHub Actions" in captured.err
-    assert "deferring to the dedicated workflow mypy step" in captured.err
+
+
+def test_main_does_not_recurse_when_no_incremental_already_supplied(monkeypatch) -> None:
+    module = _load_module()
+
+    calls: list[list[str]] = []
+
+    def _fake_run(command):
+        calls.append(list(command))
+        return CompletedProcess(
+            list(command),
+            2,
+            stdout="",
+            stderr=f"{module.MYPY_INTERNAL_ERROR_MARKER}\n",
+        )
+
+    monkeypatch.setattr(module, "_run_mypy", _fake_run)
+
+    exit_code = module.main([module.NO_INCREMENTAL_FLAG])
+
+    assert exit_code == 2
+    assert calls == [[*_expected_base_command(), module.NO_INCREMENTAL_FLAG]]
+
+
+def test_main_passes_through_extra_arguments(monkeypatch) -> None:
+    module = _load_module()
+
+    calls: list[list[str]] = []
+
+    def _fake_run(command):
+        calls.append(list(command))
+        return CompletedProcess(list(command), 0, stdout="", stderr="")
+
+    monkeypatch.setattr(module, "_run_mypy", _fake_run)
+
+    exit_code = module.main(["--show-error-codes"])
+
+    assert exit_code == 0
+    assert calls == [[*_expected_base_command(), "--show-error-codes"]]


### PR DESCRIPTION
## Summary

Makes mypy behavior consistent between local pre-commit and CI, with portable defaults and incremental caching preserved locally.

## Changes

- **`scripts/run_mypy_precommit.py`** rewritten as a portable wrapper:
  - Uses `sys.executable` instead of a hardcoded `.venv/Scripts/python.exe` path (fixes Windows/Linux/Docker portability).
  - Always runs the full project scope defined by `tool.mypy.files` in `pyproject.toml`.
  - Retries once with `--no-incremental` on `INTERNAL ERROR` (skipped if the flag is already supplied).
  - Removes the `GITHUB_ACTIONS` silent-pass branch so CI and local runs execute identical logic.
- **`tests/test_run_mypy_precommit.py`** rewritten: 7 tests covering base command shape, default run, retry-on-internal-error, no-retry-on-type-errors, persistent-error exit code propagation, no-recursion, and extra-args passthrough. No machine-specific paths.
- **`.pre-commit-config.yaml`**: added `pass_filenames: false` to the mypy hook so the script isn't handed positional args it ignores.
- **`.github/workflows/validate.yml`**: removed `SKIP: mypy` env block and the standalone `Run mypy` step. Pre-commit is now the single source of truth for mypy in CI.

## Behavior

- **Locally**: `pre-commit run mypy` (or full `pre-commit run --all-files`) runs full-project mypy with incremental caching via `.mypy_cache/`. Fast on re-runs.
- **In CI**: same command runs through the same wrapper with the same scope — no special-casing. Still benefits from the retry-on-internal-error safety net.

## Validation

- `python -m pytest tests/test_run_mypy_precommit.py -v` — 7 passed
- `python -m pre_commit run --all-files` — all hooks pass (mypy included)